### PR TITLE
Dynamically decode nodes in Accidental for element or attribute

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash",
-        "state": {
-          "branch": null,
-          "revision": "9ba116841126f6c63435beef21a4cd247c32d2e7",
-          "version": "4.7.6"
-        }
-      },
-      {
         "package": "XMLCoder",
         "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder",
         "state": {
           "branch": null,
-          "revision": "81d07bb58a38080d91241df920fdd00108f1c2b5",
-          "version": "0.2.1"
+          "revision": "5cd2ebbafe71e4d08c7f8e75f3c9591087cd2ff3",
+          "version": "0.4.1"
         }
       }
     ]

--- a/Sources/MusicXML/Model/Elements/Attributes/Attributes.swift
+++ b/Sources/MusicXML/Model/Elements/Attributes/Attributes.swift
@@ -31,6 +31,7 @@
 //    staves?, part-symbol?, instruments?, clef*, staff-details*,
 //    transpose*, directive*, measure-style*)>
 public struct Attributes: Equatable {
+
     let editorial: Editorial?
     let divisions: Divisions?
     let keys: [Key]?
@@ -43,6 +44,37 @@ public struct Attributes: Equatable {
     let transpose: [Transpose]?
     let directive: [Directive]?
     let measureStyles: [MeasureStyle]?
+
+    // MARK: - Initializers
+
+//    public init(
+//        editorial: Editorial? = nil,
+//        divisions: Divisions? = nil,
+//        keys: [Key]? = nil,
+//        time: [Time]? = nil,
+//        staves: Staves? = nil,
+//        partSymbol: PartSymbol? = nil,
+//        instruments: Instruments? = nil,
+//        clefs: [Clef]? = nil,
+//        staffDetails: [StaffDetails]? = nil,
+//        transpose: [Transpose]? = nil,
+//        directive: [Directive]? = nil,
+//        measureStyles: [MeasureStyle]? = nil
+//    )
+//    {
+//        self.editorial = editorial
+//        self.divisions = divisions
+//        self.keys = keys
+//        self.time = time
+//        self.staves = staves
+//        self.partSymbol = partSymbol
+//        self.instruments = instruments
+//        self.clefs = clefs
+//        self.staffDetails = staffDetails
+//        self.transpose = transpose
+//        self.directive = directive
+//        self.measureStyles = measureStyles
+//    }
 }
 
 // > Musical notation duration is commonly represented as

--- a/Sources/MusicXML/Model/Elements/Attributes/Attributes.swift
+++ b/Sources/MusicXML/Model/Elements/Attributes/Attributes.swift
@@ -44,37 +44,6 @@ public struct Attributes: Equatable {
     let transpose: [Transpose]?
     let directive: [Directive]?
     let measureStyles: [MeasureStyle]?
-
-    // MARK: - Initializers
-
-//    public init(
-//        editorial: Editorial? = nil,
-//        divisions: Divisions? = nil,
-//        keys: [Key]? = nil,
-//        time: [Time]? = nil,
-//        staves: Staves? = nil,
-//        partSymbol: PartSymbol? = nil,
-//        instruments: Instruments? = nil,
-//        clefs: [Clef]? = nil,
-//        staffDetails: [StaffDetails]? = nil,
-//        transpose: [Transpose]? = nil,
-//        directive: [Directive]? = nil,
-//        measureStyles: [MeasureStyle]? = nil
-//    )
-//    {
-//        self.editorial = editorial
-//        self.divisions = divisions
-//        self.keys = keys
-//        self.time = time
-//        self.staves = staves
-//        self.partSymbol = partSymbol
-//        self.instruments = instruments
-//        self.clefs = clefs
-//        self.staffDetails = staffDetails
-//        self.transpose = transpose
-//        self.directive = directive
-//        self.measureStyles = measureStyles
-//    }
 }
 
 // > Musical notation duration is commonly represented as

--- a/Tests/MusicXMLTests/AttributesDecoderTests.swift
+++ b/Tests/MusicXMLTests/AttributesDecoderTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-import MusicXML
+@testable import MusicXML
 
 class AttributesDecoderTests: XCTestCase {
 
@@ -38,5 +38,61 @@ class AttributesDecoderTests: XCTestCase {
         </clef>
         """
         XCTAssertNoThrow(try XMLDecoder().decode(Clef.self, from: xml.data(using:. utf8)!))
+    }
+
+    func testAttributes() {
+        let xml = """
+        <attributes>
+            <divisions>1</divisions>
+            <time>
+                <beats>4</beats>
+                <beat-type>4</beat-type>
+            </time>
+            <key>
+                <fifths>0</fifths>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </key>
+        </attributes>
+        """
+        let expected = Attributes(
+            editorial: nil,
+            divisions: 1,
+            keys: [
+                Key(
+                    kind: .traditional(.init(fifths: 0, cancel: nil, mode: nil)),
+                    number: nil,
+                    octaves: nil,
+                    id: nil
+                )
+            ],
+            time: [
+                Time(
+                    kind: .measured(
+                        .init(
+                            signatures: [
+                                .init(beats: 4, beatType: 4)
+                            ],
+                            interchangeable: nil
+                        )
+                    ),
+                    symbol: .common,
+                    separator: .horizontal,
+                    id: nil
+                )
+            ],
+            staves: nil,
+            partSymbol: nil,
+            instruments: nil,
+            clefs: nil,
+            staffDetails: nil,
+            transpose: nil,
+            directive: nil,
+            measureStyles: nil
+        )
+        let attributes = try! XMLDecoder().decode(Attributes.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(attributes, expected)
     }
 }

--- a/Tests/MusicXMLTests/NoteDecoderTests.swift
+++ b/Tests/MusicXMLTests/NoteDecoderTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-import MusicXML
+@testable import MusicXML
 
 class NoteDecoderTests: XCTestCase {
 
@@ -18,10 +18,12 @@ class NoteDecoderTests: XCTestCase {
           <octave>4</octave>
         </pitch>
         """
-        XCTAssertNoThrow(try XMLDecoder().decode(Pitch.self, from: xml.data(using: .utf8)!))
+        let expected = Pitch(step: .c, alter: nil, octave: 4)
+        let pitch = try! XMLDecoder().decode(Pitch.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(pitch, expected)
     }
 
-    func testNote() {
+    func testNoteThin() {
         let xml = """
         <note>
             <pitch>
@@ -32,23 +34,56 @@ class NoteDecoderTests: XCTestCase {
             <type>whole</type>
         </note>
         """
-        XCTAssertNoThrow(try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!))
+        let expected = Note(
+            pitch: Pitch(step: .c, alter: nil, octave: 4),
+            duration: 4,
+            durationType: .init(kind: .whole, size: nil),
+            accidental: nil
+        )
+        let note = try! XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(note, expected)
     }
 
-    func testMusicData() {
+    func testNoteFull() {
         let xml = """
-        <note>
+        <note default-x="83">
             <pitch>
-                <step>C</step>
-                <octave>3</octave>
+                <step>A</step>
+                <alter>1</alter>
+                <octave>4</octave>
             </pitch>
-            <duration>1</duration>
+            <duration>2</duration>
             <voice>1</voice>
             <type>quarter</type>
+            <accidental>sharp</accidental>
+            <stem default-y="10.5">up</stem>
         </note>
         """
-        XCTAssertNoThrow(
-            try XMLDecoder().decode([MusicData.Datum].self, from: xml.data(using: .utf8)!)
+        let expected = Note(
+            pitch: Pitch(step: .a, alter: 1, octave: 4),
+            duration: 2,
+            durationType: .init(kind: .quarter, size: nil),
+            accidental: Accidental(.sharp)
         )
+        let note = try! XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(expected, note)
+    }
+
+    func testAccidental() {
+        let xml = """
+        <accidental>sharp</accidental>
+        """
+        let expected = Accidental(.sharp)
+        let accidental = try! XMLDecoder().decode(Accidental.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(accidental, expected)
+    }
+
+    func testAccidentalParenthetical() {
+        let xml = """
+        <accidental parentheses="yes">natural</accidental>
+        """
+        let expected = Accidental(.natural, parentheses: true)
+        let accidental = try! XMLDecoder().decode(Accidental.self, from: xml.data(using: .utf8)!)
+        XCTAssertEqual(accidental, expected)
     }
 }

--- a/Tests/MusicXMLTests/ScoreDecoderTests.swift
+++ b/Tests/MusicXMLTests/ScoreDecoderTests.swift
@@ -75,6 +75,8 @@ class ScoreDecoderTests: XCTestCase {
         XCTAssertNoThrow(
             try XMLDecoder().decode(Score.Partwise.Part.self, from: xml.data(using: .utf8)!)
         )
+        let part = try! XMLDecoder().decode(Score.Partwise.Part.self, from: xml.data(using: .utf8)!)
+        dump(part)
     }
 
     func testPartList() {

--- a/Tests/MusicXMLTests/XCTestManifests.swift
+++ b/Tests/MusicXMLTests/XCTestManifests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 extension AttributesDecoderTests {
     static let __allTests = [
+        ("testAttributes", testAttributes),
         ("testClef", testClef),
         ("testKey", testKey),
         ("testTime", testTime),
@@ -23,8 +24,9 @@ extension IdentificationDecoderTests {
 
 extension NoteDecoderTests {
     static let __allTests = [
-        ("testMusicData", testMusicData),
-        ("testNote", testNote),
+        ("testAccidental", testAccidental),
+        ("testNoteFull", testNoteFull),
+        ("testNoteThin", testNoteThin),
         ("testPitch", testPitch),
     ]
 }


### PR DESCRIPTION
With version 0.4.0 of XMLCoder, we can now decode nodes as elements or attributes. This is important for things like `Accidental`, which carries with it elements and attributes.

Closes #17.