### PR TITLE
Reengage tuplet tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "XMLCoder",
-        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder",
+        "repositoryURL": "https://github.com/bwetherfield/XMLCoder",
         "state": {
-          "branch": null,
-          "revision": "f68964b14c34f73f2a6fa56f30d8a355e21afc25",
-          "version": "0.8.0"
+          "branch": "fix-nested-choice-array",
+          "revision": "e1470331fcc2ce22a92aebb7c1e056f7938dd46b",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder", from: "0.8.0")
+        .package(url: "https://github.com/bwetherfield/XMLCoder", .branch("fix-nested-choice-array"))
     ],
     targets: [
         .target(

--- a/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
@@ -11,8 +11,7 @@ import XMLCoder
 
 class NotationsTests: XCTestCase {
 
-    #warning("FIXME: #56 Notations.Notation.tuplet not decoding properly yet")
-    func DISABLED_testTuplet() throws {
+    func testTuplet() throws {
         let xml = """
         <notations>
           <tuplet number="1" type="start"/>

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -71,8 +71,7 @@ class NoteTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
-    #warning("FIXME: #56 Notations.Notation.tuplet not decoding properly yet")
-    func DISABLED_testTuplet() throws {
+    func testTuplet() throws {
         let xml = """
         <note>
           <pitch>

--- a/Tests/MusicXMLTests/LilyPondTests/Partwise/23_Tuplets/Partwise_23_Tuplets.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/Partwise/23_Tuplets/Partwise_23_Tuplets.swift
@@ -10,7 +10,7 @@ import MusicXML
 
 class Partwise_23_Tuplets: XCTestCase {
 
-    #warning("FIXME: #56 Notations.Notation.tuplet not decoding properly yet")
+    #warning("FIXME: #41 Note.dots not decoding properly yet")
     func DISABLED_test_23_Tuplets_E_Tremolo() throws {
         let _ = try MusicXML(string: E_Tremolo)
     }

--- a/Tests/MusicXMLTests/LilyPondTests/Timewise/23_Tuplets/Timewise_23_Tuplets.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/Timewise/23_Tuplets/Timewise_23_Tuplets.swift
@@ -11,7 +11,7 @@ import MusicXML
 class Timewise_23_Tuplets: XCTestCase {
 
     #warning("FIXME: #56 Notations.Notation.tuplet not decoding properly yet")
-    func DISABLEd_test_23_Tuplets_E_Tremolo() throws {
+    func DISABLED_test_23_Tuplets_E_Tremolo() throws {
         let _ = try MusicXML(string: E_Tremolo)
     }
 


### PR DESCRIPTION
This PR reengages a few previously-failing tuplet tests, with @bwetherfield's upstream `XMLCoder` bug fix.