### PR TITLE
Store a Note's chord as a Bool

### DIFF
--- a/Sources/MusicXML/Complex Types/Note.swift
+++ b/Sources/MusicXML/Complex Types/Note.swift
@@ -59,7 +59,7 @@ extension Note {
             case ties
             case pitchUnpitchedOrRest
         }
-        public var chord: Empty?
+        public var chord = false
         public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
         public var duration: Int
         public var ties: [Tie] // FIXME: Make Ties struct
@@ -71,7 +71,7 @@ extension Note {
             case pitchUnpitchedOrRest
             case duration
         }
-        public var chord: Empty?
+        public var chord = false
         public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
         public var duration: Int
     }
@@ -82,7 +82,7 @@ extension Note {
             case pitchUnpitchedOrRest
             case ties = "tie"
         }
-        public var chord: Empty?
+        public var chord = false
         public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
         public var ties: [Tie] // FIXME: Make Ties struct
     }
@@ -127,6 +127,8 @@ extension Note: Codable {
         case lyrics
         case play
     }
+    #warning("Handle Ties decode once Ties struct is in place")
+    #warning("Reinstate Note.dots when we can decode potentially-empty elements properly")
     public init(from decoder: Decoder) throws {
         // Ignore attributes for now
         // Decode elements
@@ -136,7 +138,7 @@ extension Note: Codable {
         self.level = try container.decodeIfPresent(Level.self, forKey: .level)
         self.voice = try container.decodeIfPresent(String.self, forKey: .voice)
         self.type = try container.decodeIfPresent(NoteType.self, forKey: .type)
-        #warning("Reinstate Note.dots when we can decode potentially-empty elements properly")
+
         // self.dots = try container.decodeIfPresent([EmptyPlacement].self, forKey: .dots)
         self.accidental = try container.decodeIfPresent(Accidental.self, forKey: .accidental)
         self.timeModification = try container.decodeIfPresent(TimeModification.self, forKey: .timeModification)
@@ -154,10 +156,9 @@ extension Note: Codable {
         // Decode kind
         do {
             let kindContainer = try decoder.container(keyedBy: Normal.CodingKeys.self)
-            #warning("Handle Ties decode once Ties struct is in place")
             self.kind = .normal(
                 Normal(
-                    chord: nil,
+                    chord: kindContainer.contains(.chord),
                     pitchUnpitchedOrRest: pitchUnpitchedOrRest,
                     duration: try kindContainer.decode(Int.self, forKey: .duration),
                     ties: []
@@ -166,20 +167,18 @@ extension Note: Codable {
         } catch {
             do {
                 let kindContainer = try decoder.container(keyedBy: Cue.CodingKeys.self)
-                #warning("Handle Ties decode once Ties struct is in place")
                 self.kind = .cue(
                     Cue(
-                        chord: nil,
+                        chord: kindContainer.contains(.chord),
                         pitchUnpitchedOrRest: pitchUnpitchedOrRest,
                         duration: try kindContainer.decode(Int.self, forKey: .duration)
                     )
                 )
             } catch {
                 let kindContainer = try decoder.container(keyedBy: Grace.CodingKeys.self)
-                #warning("Handle Ties decode once Ties struct is in place")
                 self.kind = .grace(
                     Note.Grace(
-                        chord: nil,
+                        chord: kindContainer.contains(.chord),
                         pitchUnpitchedOrRest: pitchUnpitchedOrRest,
                         ties: []
                     )

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -28,7 +28,7 @@ class NoteTests: XCTestCase {
         let expected = Note(
             kind: .normal(
                 Note.Normal(
-                    chord: nil,
+                    chord: false,
                     pitchUnpitchedOrRest: .pitch(Pitch(step: .c, alter: -1.5, octave: 4)),
                     duration: 1,
                     ties: []
@@ -58,7 +58,6 @@ class NoteTests: XCTestCase {
         let expected = Note(
             kind: .normal(
                 Note.Normal(
-                    chord: nil,
                     pitchUnpitchedOrRest: .pitch(Pitch(step: .g, alter: 1, octave: 2)),
                     duration: 1,
                     ties: []
@@ -115,14 +114,13 @@ class NoteTests: XCTestCase {
           <duration>48</duration>
           <voice>1</voice>
           <type>quarter</type>
-          <dot></dot>
+          <dot/>
         </note>
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
             kind: .normal(
                 Note.Normal(
-                    chord: nil,
                     pitchUnpitchedOrRest: .rest(
                         Rest(/*displayStep: nil, displayOctave: nil, measure: nil*/)
                     ),

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -106,6 +106,23 @@ class NoteTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
+    #warning("FIXME: #68 Chord not decoding properly")
+    func DISABLED_testChord() throws {
+        let xml = """
+        <note>
+          <chord/>
+          <pitch>
+            <step>E</step><octave>5</octave>
+          </pitch>
+          <duration>1</duration>
+          <voice>1</voice>
+          <type>quarter</type>
+        </note>
+        """
+        let expected = Note(kind: .normal(Note.Normal(chord: true, pitchUnpitchedOrRest: .pitch(Pitch(step: .e, octave: 5)), duration: 1, ties: [])), voice: "1", type: NoteType(value: .quarter))
+        try assertDecoded(xml, equals: expected)
+    }
+
     #warning("FIXME: #41 Note.dots not decoding properly yet")
     func DISABLED_testNoteDottedRestDecoding() throws {
         let xml = """


### PR DESCRIPTION
A `<note>` may have a `<chord/>` element, which signals that this `<note>` belongs to a chord. However, because of #68, this `<chord/>` element is not decoding properly yet.

This PR models a `Note`'s `chord` property as a `Bool` rather than the metaphysical `Empty?`.