### PR TITLE
[WIP] Add nice APIs for Key and Time

### DIFF
--- a/Sources/MusicXML/Complex Types/Key.swift
+++ b/Sources/MusicXML/Complex Types/Key.swift
@@ -11,7 +11,9 @@ import XMLCoder
 /// supported. If absent, the key signature applies to all staves in the part. Key signatures appear
 /// at the start of each system unless the print-object attribute has been set to "no".
 public struct Key {
+
     // MARK: - Attributes
+
     /// The optional number attribute refers to staff numbers.
     public var number: Int?
     public var position: Position?
@@ -19,8 +21,28 @@ public struct Key {
     public var printObject: Bool?
 
     // MARK: - Elements
+
     public var kind: Kind
     public var keyOctave: [KeyOctave]?
+}
+
+extension Key {
+
+    // MARK: - Initializers
+
+    /// Creates a `Traditional` type `Key`.
+    public init(fifths: Int, cancel: Cancel? = nil, mode: Mode? = nil) {
+        self.kind = .traditional(Traditional(cancel: cancel, fifths: fifths, mode: mode))
+        // TODO: Add remaining attirbutes and elements
+    }
+
+    /// Creates a `NonTraditional` type `Key`.
+    public init(step: Step, alter: Double, accidental: AccidentalValue) {
+        self.kind = .nonTraditional(
+            NonTraditional(step: step, alter: alter, accidental: accidental)
+        )
+        // TODO: Add remaining attirbutes and elements
+    }
 }
 
 extension Key {

--- a/Sources/MusicXML/Complex Types/Key.swift
+++ b/Sources/MusicXML/Complex Types/Key.swift
@@ -31,9 +31,10 @@ extension Key {
     // MARK: - Initializers
 
     /// Creates a `Traditional` type `Key`.
-    public init(fifths: Int, cancel: Cancel? = nil, mode: Mode? = nil) {
+    public init(fifths: Int, cancel: Cancel? = nil, mode: Mode? = nil, staff: Int? = nil) {
+        self.number = staff
         self.kind = .traditional(Traditional(cancel: cancel, fifths: fifths, mode: mode))
-        // TODO: Add remaining attirbutes and elements
+        // TODO: Add remaining attributes and elements
     }
 
     /// Creates a `NonTraditional` type `Key`.
@@ -41,7 +42,7 @@ extension Key {
         self.kind = .nonTraditional(
             NonTraditional(step: step, alter: alter, accidental: accidental)
         )
-        // TODO: Add remaining attirbutes and elements
+        // TODO: Add remaining attributes and elements
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Time.swift
+++ b/Sources/MusicXML/Complex Types/Time.swift
@@ -55,8 +55,16 @@ extension Time {
     ///     let _ = Time(4,4)
     ///     let _ = Time(3, 16, staff: 3)
     ///
-    public init(_ beats: Int, _ beatType: Int, staff: Int? = nil, interchangeable: Interchangeable?) {
+    public init(
+        _ beats: Int,
+        _ beatType: Int,
+        symbol: TimeSymbol? = nil,
+        staff: Int? = nil,
+        interchangeable: Interchangeable? = nil
+    )
+    {
         self.number = staff
+        self.symbol = symbol
         self.kind = .measured(
             Measured(
                 signature: Time.Signature(beats: beats, beatType: beatType),

--- a/Sources/MusicXML/Complex Types/Time.swift
+++ b/Sources/MusicXML/Complex Types/Time.swift
@@ -40,7 +40,43 @@ public struct Time {
     public var printObject: Bool?
 
     // MARK: - Elements
+
     public var kind: Kind
+}
+
+extension Time {
+
+    // MARK: - Initializers
+
+    /// Creates a `Measured` type `Time`.
+    ///
+    /// **Example Usage:**
+    ///
+    ///     let _ = Time(4,4)
+    ///     let _ = Time(3, 16, staff: 3)
+    ///
+    public init(_ beats: Int, _ beatType: Int, staff: Int? = nil, interchangeable: Interchangeable?) {
+        self.number = staff
+        self.kind = .measured(
+            Measured(
+                signature: Time.Signature(beats: beats, beatType: beatType),
+                interchangeable: interchangeable
+            )
+        )
+        // TODO: Add remaining attributes and elements
+    }
+
+    /// Creates an `Unmeasured` type `Time`.
+    ///
+    /// **Example Usage:**
+    ///
+    ///     let _ = Time(symbol: "XXX")
+    ///
+    public init(symbol: String? = nil, staff: Int? = nil) {
+        self.number = staff
+        self.kind = .unmeasured(Unmeasured(symbol: symbol))
+        // TODO: Add remaining attributes and elements
+    }
 }
 
 extension Time {

--- a/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
@@ -32,9 +32,7 @@ class AttributesTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Attributes.self, from: xml.data(using: .utf8)!)
         let expected = Attributes(
             divisions: 1,
-            keys: [
-                Key(kind: .traditional(Key.Traditional(cancel: nil, fifths: 0, mode: .major)))
-            ],
+            keys: [Key(fifths: 0, mode: .major)],
             times: [
                 Time(
                     symbol: .common,

--- a/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
@@ -33,14 +33,7 @@ class AttributesTests: XCTestCase {
         let expected = Attributes(
             divisions: 1,
             keys: [Key(fifths: 0, mode: .major)],
-            times: [
-                Time(
-                    symbol: .common,
-                    kind: .measured(
-                        Time.Measured(signature: Time.Signature(beats: 4, beatType: 4))
-                    )
-                )
-            ],
+            times: [Time(4, 4, symbol: .common)],
             clefs: [Clef(sign: .g, line: 2)]
         )
         XCTAssertEqual(decoded, expected)

--- a/Tests/MusicXMLTests/Complex Types/KeyTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/KeyTests.swift
@@ -19,7 +19,7 @@ class KeyTests: XCTestCase {
         </key>
         """
         let decoded = try XMLDecoder().decode(Key.self, from: xml.data(using: .utf8)!)
-        let expected = Key(kind: .traditional(Key.Traditional(fifths: 0, mode: .major)))
+        let expected = Key(fifths: 0, mode: .major)
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/MusicDataTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MusicDataTests.swift
@@ -52,14 +52,7 @@ class MusicDataTests: XCTestCase {
                             kind: .traditional(Key.Traditional(fifths: 0, mode: .major))
                         )
                     ],
-                    times: [
-                        Time(
-                            symbol: .common,
-                            kind: .measured(
-                                Time.Measured(signature: Time.Signature(beats: 4, beatType: 4))
-                            )
-                        )
-                    ],
+                    times: [Time(4, 4, symbol: .common)],
                     clefs: [Clef(sign: .g, line: 2)]
                 )
             )

--- a/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
@@ -50,16 +50,7 @@ class PartwiseMeasureTests: XCTestCase {
                     Attributes(
                         divisions: 1,
                         keys: [Key(fifths: 0, mode: .major)],
-                        times: [
-                            Time(
-                                symbol: .common,
-                                kind: .measured(
-                                    Time.Measured(
-                                        signature: Time.Signature(beats: 4, beatType: 4)
-                                    )
-                                )
-                            )
-                        ],
+                        times: [Time(4, 4, symbol: .common)],
                         clefs: [Clef(sign: .g, line: 2)]
                     )
                 )
@@ -133,14 +124,7 @@ class PartwiseMeasureTests: XCTestCase {
                     Attributes(
                         divisions: 1,
                         keys: [Key(fifths: 0, mode: .major)],
-                        times: [
-                            Time(
-                                symbol: .common,
-                                kind: .measured(
-                                    Time.Measured(signature: Time.Signature(beats: 4, beatType: 4))
-                                )
-                            )
-                        ],
+                        times: [Time(4, 4, symbol: .common)],
                         clefs: [
                             Clef(sign: .g, line: 2)
                         ]

--- a/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
@@ -49,9 +49,7 @@ class PartwiseMeasureTests: XCTestCase {
                 .attributes(
                     Attributes(
                         divisions: 1,
-                        keys: [
-                            Key(kind: .traditional(Key.Traditional(fifths: 0, mode: .major)))
-                        ],
+                        keys: [Key(fifths: 0, mode: .major)],
                         times: [
                             Time(
                                 symbol: .common,
@@ -134,9 +132,7 @@ class PartwiseMeasureTests: XCTestCase {
                 .attributes(
                     Attributes(
                         divisions: 1,
-                        keys: [
-                            Key(kind: .traditional(Key.Traditional(fifths: 0, mode: .major)))
-                        ],
+                        keys: [Key(fifths: 0, mode: .major)],
                         times: [
                             Time(
                                 symbol: .common,

--- a/Tests/MusicXMLTests/Complex Types/TimeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/TimeTests.swift
@@ -31,12 +31,7 @@ class TimeTests: XCTestCase {
         </time>
         """
         let decoded = try XMLDecoder().decode(Time.self, from: xml.data(using: .utf8)!)
-        let expected = Time(
-            symbol: .common,
-            kind: Time.Kind.measured(
-                Time.Measured(signature: Time.Signature(beats: 4, beatType: 4))
-            )
-        )
+        let expected = Time(4, 4, symbol: .common)
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/HelloWorld.swift
+++ b/Tests/MusicXMLTests/HelloWorld.swift
@@ -71,25 +71,8 @@ class HelloWorld: XCTestCase {
                                             .attributes(
                                                 Attributes(
                                                     divisions: 1,
-                                                    keys: [
-                                                        Key(
-                                                            kind: .traditional(
-                                                                Key.Traditional(fifths: 0)
-                                                            )
-                                                        )
-                                                    ],
-                                                    times: [
-                                                        Time(
-                                                            kind: .measured(
-                                                                Time.Measured(
-                                                                    signature: Time.Signature(
-                                                                        beats: 4,
-                                                                        beatType: 4
-                                                                    )
-                                                                )
-                                                            )
-                                                        )
-                                                    ],
+                                                    keys: [Key(fifths: 0)],
+                                                    times: [Time(4, 4)],
                                                     clefs: [Clef(sign: .g, line: 2)]
                                                 )
                                             ),


### PR DESCRIPTION
The `Key` and `Time` types can each represent one of a couple known kinds.

Instead of having to initialize `Key` and `Time` with the `Kind` directly, this PR adds multiple initializers that cut directly to defining the `Kind`. 

For example, now you can define a `Time` element like this:

```Swift
let _ = Time(4,4)
let _ = Time(3, 16, staff: 3)
```
or 
```Swift
let _ = Time(symbol: "XXX")
```