### PR TITLE
Configure code coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,9 @@ env:
 script:
   - swift package update
   - swift package generate-xcodeproj
-  - if [ $TRAVIS_OS_NAME = 'osx' ]; then xcodebuild -quiet -project MusicXML.xcodeproj -scheme MusicXML-Package -enableCodeCoverage YES build test; else swift test; fi
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ $TRAVIS_OS_NAME = 'osx' ]; then 
+      xcodebuild -quiet -project MusicXML.xcodeproj -scheme MusicXML-Package -enableCodeCoverage YES build test; 
+      bash <(curl -s https://codecov.io/bash);
+    else 
+      swift test; 
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
   - SWIFT_VERSION=DEVELOPMENT-SNAPSHOT-2019-08-01-a CODECOV_TOKEN=52103015-769c-4c59-b537-4fa9fe91c41c
 script:
   - swift package update
-  - swift package generate-xcodeproj
   - if [ $TRAVIS_OS_NAME = 'osx' ]; then 
+      swift package generate-xcodeproj;
       xcodebuild -quiet -project MusicXML.xcodeproj -scheme MusicXML-Package -enableCodeCoverage YES build test; 
       bash <(curl -s https://codecov.io/bash);
     else 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "Tests"


### PR DESCRIPTION
This PR refines the configuration of the code coverage gathering process in several ways:

- Ask codecov.io to ignore the `Tests` directory for a more honest view of coverage
- Only `generate-xcodeproj` if we are on a Mac
- Only gather coverage if we are on a Mac