### PR TITLE
Fix type errors in ScorePart and added tests

### DIFF
--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -9,7 +9,7 @@
 /// be a part of either the score-instrument element at the start of a part, or the sound element
 /// within a part. The id attribute refers to the score-instrument affected by the change.
 public struct MIDIInstrument {
-    public let id: Int
+    public let id: String
     /// The midi-channel element specifies a MIDI 1.0 channel number ranging from 1 to 16.
     public let midiChannel: Int?
     /// The midi-name element corresponds to a ProgramName meta-event within a Standard MIDI File.
@@ -26,7 +26,7 @@ public struct MIDIInstrument {
     /// The volume element value is a percentage of the maximum ranging from 0 to 100, with decimal
     /// values allowed. This corresponds to a scaling value for the MIDI 1.0 channel volume
     /// controller.
-    public let volume: Int?
+    public let volume: Double?
     /// The pan and elevation elements allow placing of sound in a 3-D space relative to the
     /// listener. Both are expressed in degrees ranging from -180 to 180. For pan, 0 is straight
     /// ahead, -90 is hard left, 90 is hard right, and -180 and 180 are directly behind the
@@ -36,6 +36,18 @@ public struct MIDIInstrument {
     /// listener. Both are expressed in degrees ranging from -180 to 180. For elevation, 0 is level
     /// with the listener, 90 is directly above, and -90 is directly below.
     public let elevation: Int?
+
+    public init(id: String, midiChannel: Int? = nil, midiName: String? = nil, midiBank: Int? = nil, midiProgram: Int? = nil, midiUnpitched: Int? = nil, volume: Double? = nil, pan: Int? = nil, elevation: Int? = nil) {
+        self.id = id
+        self.midiChannel = midiChannel
+        self.midiName = midiName
+        self.midiBank = midiBank
+        self.midiProgram = midiProgram
+        self.midiUnpitched = midiUnpitched
+        self.volume = volume
+        self.pan = pan
+        self.elevation = elevation
+    }
 }
 
 extension MIDIInstrument: Equatable { }

--- a/Sources/MusicXML/Complex Types/ScoreInstrument.swift
+++ b/Sources/MusicXML/Complex Types/ScoreInstrument.swift
@@ -16,9 +16,18 @@ public struct ScoreInstrument {
     public let id: String
     public let instrumentName: String
     public let instrumentAbbreviation: String?
-    public let sound: String
+    public let sound: String?
     public let soloOrEnsemble: SoloEnsemble?
     public let virtualInstrument: VirtualInstrument?
+
+    public init(id: String, instrumentName: String, instrumentAbbreviation: String? = nil, sound: String? = nil, soloOrEnsemble: SoloEnsemble? = nil, virtualInstrument: VirtualInstrument? = nil) {
+        self.id = id
+        self.instrumentName = instrumentName
+        self.instrumentAbbreviation = instrumentAbbreviation
+        self.sound = sound
+        self.soloOrEnsemble = soloOrEnsemble
+        self.virtualInstrument = virtualInstrument
+    }
 }
 
 extension ScoreInstrument {
@@ -55,4 +64,13 @@ extension ScoreInstrument.SoloEnsemble: Codable {
 }
 
 extension ScoreInstrument: Equatable { }
-extension ScoreInstrument: Codable { }
+extension ScoreInstrument: Codable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case instrumentName = "instrument-name"
+        case instrumentAbbreviation = "instrument-abbreviation"
+        case sound
+        case soloOrEnsemble
+        case virtualInstrument = "virtual-instrument"
+    }
+}

--- a/Sources/MusicXML/Complex Types/ScorePart.swift
+++ b/Sources/MusicXML/Complex Types/ScorePart.swift
@@ -102,6 +102,7 @@ extension ScorePart: Codable {
         case partAbbreviationDisplay = "part-abbreviation-display"
         case group
         case scoreInstrument = "score-instrument"
+        #warning("TODO: Properly decode midi-channel and midi-program. See score.mod:172")
         case midi
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
@@ -1,0 +1,25 @@
+//
+//  ScoreInstrumentTests.swift
+//  MusicXMLTests
+//
+//  Created by Ben Lu on 9/26/19.
+//
+
+import XCTest
+import XMLCoder
+@testable import MusicXML
+
+class ScoreInstrumentTests: XCTestCase {
+    func testDecoding() throws {
+        let xml =
+        """
+        <score-instrument id="P1-I1">
+            <instrument-name>Piano</instrument-name>
+        </score-instrument>
+        """
+        let decoded = try XMLDecoder().decode(ScoreInstrument.self, from: xml.data(using: .utf8)!)
+        let expected = ScoreInstrument(id: "P1-I1", instrumentName: "Piano")
+
+        XCTAssertEqual(decoded, expected)
+    }
+}

--- a/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
@@ -21,4 +21,35 @@ class ScorePartTests: XCTestCase {
         let expected = ScorePart(id: "P1", name: PartName(value: "MusicXML Part"))
         XCTAssertEqual(decoded, expected)
     }
+
+    func testDecoding_complex() throws {
+        // Adopted from MuseScore export
+        let xml = """
+        <score-part id="P1">
+            <part-name>Piano</part-name>
+            <part-abbreviation>Pno.</part-abbreviation>
+            <score-instrument id="P1-I1">
+                <instrument-name>Piano</instrument-name>
+            </score-instrument>
+            <midi-device id="P1-I1" port="1"></midi-device>
+            <midi-instrument id="P1-I1">
+                <midi-channel>1</midi-channel>
+                <midi-program>1</midi-program>
+                <volume>78.7402</volume>
+                <pan>0</pan>
+            </midi-instrument>
+        </score-part>
+        """
+
+        let decoded = try XMLDecoder().decode(ScorePart.self, from: xml.data(using: .utf8)!)
+        let expected = ScorePart(
+            id: "P1",
+            name: PartName(value: "Piano"),
+            partAbbreviation: PartName(value: "Pno."),
+            scoreInstrument: [ScoreInstrument(id: "P1-I1", instrumentName: "Piano")]
+            // TODO: midi-channel and midi-program are not decoding properly
+//            midi: [ScorePart.MIDI(midiDevice: MIDIDevice(value: "", port: 1, id: "P1-I1"), midiInstrument: MIDIInstrument(id: "P1-I1", midiChannel: 1, midiProgram: 1, volume: 78.7402, pan: 0))]
+        )
+        XCTAssertEqual(decoded, expected)
+    }
 }


### PR DESCRIPTION
- [`instrument-sound`](https://github.com/w3c/musicxml/blob/gh-pages/schema/score.mod#L320) is optional
- Fixed `score-instrument` decoding by adding proper decoding keys and added tests
- Corrected `id` type of `midi-instrument` to `String`
-  Corrected `volume` type of `midi-instrument` to `Double`, because it may take decimal values