### PR TITLE
Use vars instead of lets so that compiler can build init

### DIFF
--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -9,45 +9,33 @@
 /// be a part of either the score-instrument element at the start of a part, or the sound element
 /// within a part. The id attribute refers to the score-instrument affected by the change.
 public struct MIDIInstrument {
-    public let id: String
+    public var id: String
     /// The midi-channel element specifies a MIDI 1.0 channel number ranging from 1 to 16.
-    public let midiChannel: Int?
+    public var midiChannel: Int?
     /// The midi-name element corresponds to a ProgramName meta-event within a Standard MIDI File.
-    public let midiName: String?
+    public var midiName: String?
     /// The midi-bank element specified a MIDI 1.0 bank number ranging from 1 to 16,384.
-    public let midiBank: Int?
+    public var midiBank: Int?
     /// The midi-program element specifies a MIDI 1.0 program number ranging from 1 to 128.
-    public let midiProgram: Int?
+    public var midiProgram: Int?
     /// For unpitched instruments, the midi-unpitched element specifies a MIDI 1.0 note number
     /// ranging from 1 to 128. It is usually used with MIDI banks for percussion. Note that MIDI 1.0
     /// note numbers are generally specified from 0 to 127 rather than the 1 to 128 numbering used
     /// in this element.
-    public let midiUnpitched: Int?
+    public var midiUnpitched: Int?
     /// The volume element value is a percentage of the maximum ranging from 0 to 100, with decimal
     /// values allowed. This corresponds to a scaling value for the MIDI 1.0 channel volume
     /// controller.
-    public let volume: Double?
+    public var volume: Double?
     /// The pan and elevation elements allow placing of sound in a 3-D space relative to the
     /// listener. Both are expressed in degrees ranging from -180 to 180. For pan, 0 is straight
     /// ahead, -90 is hard left, 90 is hard right, and -180 and 180 are directly behind the
     /// listener.
-    public let pan: Int?
+    public var pan: Int?
     /// The elevation and pan elements allow placing of sound in a 3-D space relative to the
     /// listener. Both are expressed in degrees ranging from -180 to 180. For elevation, 0 is level
     /// with the listener, 90 is directly above, and -90 is directly below.
-    public let elevation: Int?
-
-    public init(id: String, midiChannel: Int? = nil, midiName: String? = nil, midiBank: Int? = nil, midiProgram: Int? = nil, midiUnpitched: Int? = nil, volume: Double? = nil, pan: Int? = nil, elevation: Int? = nil) {
-        self.id = id
-        self.midiChannel = midiChannel
-        self.midiName = midiName
-        self.midiBank = midiBank
-        self.midiProgram = midiProgram
-        self.midiUnpitched = midiUnpitched
-        self.volume = volume
-        self.pan = pan
-        self.elevation = elevation
-    }
+    public var elevation: Int?
 }
 
 extension MIDIInstrument: Equatable { }

--- a/Sources/MusicXML/Complex Types/PitchUnpitchedRest.swift
+++ b/Sources/MusicXML/Complex Types/PitchUnpitchedRest.swift
@@ -32,7 +32,6 @@ extension PitchUnpitchedOrRest: Codable {
                 do {
                     self = .rest(try container.decode(Rest.self, forKey: .rest))
                 } catch {
-                    print(error)
                     throw error
                 }
 

--- a/Sources/MusicXML/Complex Types/ScoreInstrument.swift
+++ b/Sources/MusicXML/Complex Types/ScoreInstrument.swift
@@ -13,21 +13,12 @@
 /// without these elements in simple cases, such as where part names match General MIDI instrument
 /// names.
 public struct ScoreInstrument {
-    public let id: String
-    public let instrumentName: String
-    public let instrumentAbbreviation: String?
-    public let sound: String?
-    public let soloOrEnsemble: SoloEnsemble?
-    public let virtualInstrument: VirtualInstrument?
-
-    public init(id: String, instrumentName: String, instrumentAbbreviation: String? = nil, sound: String? = nil, soloOrEnsemble: SoloEnsemble? = nil, virtualInstrument: VirtualInstrument? = nil) {
-        self.id = id
-        self.instrumentName = instrumentName
-        self.instrumentAbbreviation = instrumentAbbreviation
-        self.sound = sound
-        self.soloOrEnsemble = soloOrEnsemble
-        self.virtualInstrument = virtualInstrument
-    }
+    public var id: String
+    public var instrumentName: String
+    public var instrumentAbbreviation: String?
+    public var sound: String?
+    public var soloOrEnsemble: SoloEnsemble?
+    public var virtualInstrument: VirtualInstrument?
 }
 
 extension ScoreInstrument {


### PR DESCRIPTION
@DJBen, I realized that you added `init`s for `MIDIInstrument` and `ScorePart`. I have started using `var`s instead of `let`s in this case so that the compiler will build the partial `init` for us.

This isn't consistent yet throughout the codebase, but it is the desired direction.

Let me know if that is unsavory for you!