### PR TITLE
Point to our branch of XMLCoder for now

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,10 +3,10 @@
     "pins": [
       {
         "package": "XMLCoder",
-        "repositoryURL": "https://github.com/bwetherfield/XMLCoder",
+        "repositoryURL": "https://github.com/jsbean/XMLCoder",
         "state": {
-          "branch": "fix-nested-choice-array",
-          "revision": "e1470331fcc2ce22a92aebb7c1e056f7938dd46b",
+          "branch": "empty-element-empty-string",
+          "revision": "e95cb2be57a5de0fc43770633de84f2c4fb0e7c0",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/bwetherfield/XMLCoder", .branch("fix-nested-choice-array"))
+        .package(url: "https://github.com/jsbean/XMLCoder", .branch("empty-element-empty-string"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
This PR points to the `jsbean` fork of `XMLCoder`.

@bwetherfield has made improvements in the quest to define nothingness. There are several examples where a `String` property is encoded as an empty element (e.g., `<part-name/>`). In this case, we want to decode `""`, not `nil`.

This enhancements here increase the amount of LilyPond tests we are parsing without throwing up from 101 to 123.