### PR TITLE
Enable decoding position and unpitched notes

### DIFF
--- a/Sources/MusicXML/Complex Types/Note.swift
+++ b/Sources/MusicXML/Complex Types/Note.swift
@@ -17,6 +17,12 @@ public struct Note {
 
     // MARK: - Attributes
 
+    public var position: Position = Position()
+    public var fontFamily: CommaSeparatedText?
+    public var fontStyle: FontStyle?
+    public var fontSize: FontSize?
+    public var fontWeight: FontWeight?
+    public var color: Color?
     public var printStyle: PrintStyle?
     public var printObject: Bool?
     public var printDot: Bool?
@@ -81,16 +87,21 @@ extension Note: Equatable { }
 extension Note: Codable {
     enum CodingKeys: String, CodingKey {
         // Attributes
-        case printStyle
-        case printObject
-        case printDot
-        case printSpacing
-        case printLyric
+        case fontFamily = "font-family"
+        case fontStyle = "font-style"
+        case fontSize = "font-size"
+        case fontWeight = "font-weight"
+        case color
+        case printStyle = "print-style"
+        case printObject = "print-object"
+        case printDot = "print-dot"
+        case printSpacing = "print-spacing"
+        case printLyric = "print-lyric"
         case dynamics
-        case endDynamics
+        case endDynamics = "end-dynamics"
         case attack
         case release
-        case timeOnly
+        case timeOnly = "time-only"
         case pizzicato
         // Elements
         case instrument
@@ -118,9 +129,26 @@ extension Note: Codable {
     }
     #warning("Reinstate Note.dots when we can decode potentially-empty elements properly")
     public init(from decoder: Decoder) throws {
-        // Ignore attributes for now
-        // Decode elements
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Attributes
+        self.position = try Position(from: decoder)
+        self.fontFamily = try container.decodeIfPresent(CommaSeparatedText.self, forKey: .fontFamily)
+        self.fontStyle = try container.decodeIfPresent(FontStyle.self, forKey: .fontStyle)
+        self.fontSize = try container.decodeIfPresent(FontSize.self, forKey: .fontSize)
+        self.fontWeight = try container.decodeIfPresent(FontWeight.self, forKey: .fontWeight)
+        self.color = try container.decodeIfPresent(Color.self, forKey: .color)
+        self.printStyle = try container.decodeIfPresent(PrintStyle.self, forKey: .printStyle)
+        self.printObject = try container.decodeIfPresent(Bool.self, forKey: .printObject)
+        self.printDot = try container.decodeIfPresent(Bool.self, forKey: .printDot)
+        self.printSpacing = try container.decodeIfPresent(Bool.self, forKey: .printSpacing)
+        self.printLyric = try container.decodeIfPresent(Bool.self, forKey: .printLyric)
+        self.dynamics = try container.decodeIfPresent(Double.self, forKey: .dynamics)
+        self.endDynamics = try container.decodeIfPresent(Double.self, forKey: .endDynamics)
+        self.attack = try container.decodeIfPresent(Divisions.self, forKey: .attack)
+        self.release = try container.decodeIfPresent(Divisions.self, forKey: .release)
+        self.timeOnly = try container.decodeIfPresent(TimeOnly.self, forKey: .timeOnly)
+        self.pizzicato = try container.decodeIfPresent(Bool.self, forKey: .pizzicato)
+        // Decode elements
         self.instrument = try container.decodeIfPresent(Instrument.self, forKey: .instrument)
         self.footnote = try container.decodeIfPresent(FormattedText.self, forKey: .footnote)
         self.level = try container.decodeIfPresent(Level.self, forKey: .level)

--- a/Sources/MusicXML/Complex Types/Position.swift
+++ b/Sources/MusicXML/Complex Types/Position.swift
@@ -58,15 +58,15 @@
 /// As elsewhere in the MusicXML format, tenths are the global tenths defined by the scaling
 /// element, not the local tenths of a staff resized by the staff-size element.
 public struct Position {
-    public var defaultX: Tenths
-    public var defaultY: Tenths
-    public var relativeX: Tenths
-    public var relativeY: Tenths
+    public var defaultX: Tenths?
+    public var defaultY: Tenths?
+    public var relativeX: Tenths?
+    public var relativeY: Tenths?
 }
 
 extension Position: Equatable { }
 extension Position: Codable {
-    private enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case defaultX = "default-x"
         case defaultY = "default-y"
         case relativeX = "relative-x"

--- a/Sources/MusicXML/Complex Types/Stem.swift
+++ b/Sources/MusicXML/Complex Types/Stem.swift
@@ -12,9 +12,21 @@
 /// associated with a rest refers to a stemlet.
 public struct Stem {
     public var value: StemValue
-    public var position: Position?
+    public var position: Position = Position()
     public var color: Color?
 }
 
 extension Stem: Equatable { }
-extension Stem: Codable { }
+extension Stem: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case value = ""
+        case color
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.value = try container.decode(StemValue.self, forKey: .value)
+        self.position = try Position(from: decoder)
+        self.color = try container.decodeIfPresent(Color.self, forKey: .color)
+    }
+}

--- a/Sources/MusicXML/Complex Types/Unpitched.swift
+++ b/Sources/MusicXML/Complex Types/Unpitched.swift
@@ -8,9 +8,14 @@
 /// The unpitched type represents musical elements that are notated on the staff but lack definite
 /// pitch, such as unpitched percussion and speaking voice.
 public struct Unpitched {
-    public let displayStep: Step?
-    public let displayOctave: Int?
+    public var displayStep: Step
+    public var displayOctave: Int
 }
 
 extension Unpitched: Equatable { }
-extension Unpitched: Codable { }
+extension Unpitched: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case displayStep = "display-step"
+        case displayOctave = "display-octave"
+    }
+}

--- a/Sources/MusicXML/Simple Types/Tenths.swift
+++ b/Sources/MusicXML/Simple Types/Tenths.swift
@@ -21,3 +21,13 @@ extension Tenths: Codable {
         value = try container.decode(Double.self)
     }
 }
+extension Tenths: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self.value = value
+    }
+}
+extension Tenths: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self.value = Double(value)
+    }
+}

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -174,6 +174,7 @@ class NoteTests: XCTestCase {
                     duration: 1
                 )
             ),
+            position: Position(defaultX: 368.91, defaultY: 0),
             voice: "1",
             type: NoteType(value: .sixteenth),
             stem: Stem(value: .down),
@@ -215,6 +216,7 @@ class NoteTests: XCTestCase {
                     ties: Ties(start: Tie(type: .start), stop: Tie(type: .stop))
                 )
             ),
+            position: Position(defaultX: 483.50, defaultY: -25.00),
             voice: "1",
             type: NoteType(value: .quarter),
             stem: Stem(value: .up),
@@ -222,6 +224,44 @@ class NoteTests: XCTestCase {
                 .tied(Tied(type: .stop)),
                 .tied(Tied(type: .start))
             ])
+        )
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testUnpitched() throws {
+        let xml = """
+        <note default-x="68">
+          <unpitched>
+            <display-step>F</display-step>
+            <display-octave>4</display-octave>
+          </unpitched>
+          <duration>1</duration>
+          <instrument id="P1-X2"/>
+          <voice>1</voice>
+          <type>eighth</type>
+          <stem default-y="-70">down</stem>
+          <beam number="1">begin</beam>
+        </note>
+        """
+        let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
+        let expected = Note(
+            kind: .normal(
+                Note.Normal(
+                    pitchUnpitchedOrRest: .unpitched(
+                        Unpitched(
+                            displayStep: .f,
+                            displayOctave: 4
+                        )
+                    ),
+                    duration: 1
+                )
+            ),
+            position: Position(defaultX: 68),
+            instrument: Instrument(id: "P1-X2"),
+            voice: "1",
+            type: NoteType(value: .eighth),
+            stem: Stem(value: .down, position: Position(defaultY: -70)),
+            beams: [Beam(value: .begin, number: .one)]
         )
         XCTAssertEqual(decoded, expected)
     }


### PR DESCRIPTION
This PR enables position decoding and fixes unpitched notes decoding.

Because of the nature of how positions are decoded, the decoder is passed to the position initializer directly to decode the `defaultX`, `defaultY`, `relativeX` and `relativeY`. If all four are `nil`, the Position will be empty of any properties but not `nil`.

Thus for structs that have positions, I provide a default initializer `let position: Position = Position()`.