### PR TITLE
De-attribute-label Stem.init re: StemValue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/jsbean/XMLCoder",
         "state": {
           "branch": "master",
-          "revision": "f2cac4397b1e4c881a93b934e459e393a67192f1",
+          "revision": "51c791f9523ce78efd742067fb32f29214d3082a",
           "version": null
         }
       }

--- a/Sources/MusicXML/Complex Types/Position.swift
+++ b/Sources/MusicXML/Complex Types/Position.swift
@@ -58,10 +58,22 @@
 /// As elsewhere in the MusicXML format, tenths are the global tenths defined by the scaling
 /// element, not the local tenths of a staff resized by the staff-size element.
 public struct Position {
-    public var defaultX: Tenths?
-    public var defaultY: Tenths?
-    public var relativeX: Tenths?
-    public var relativeY: Tenths?
+    public let defaultX: Tenths?
+    public let defaultY: Tenths?
+    public let relativeX: Tenths?
+    public let relativeY: Tenths?
+
+    public init(
+        defaultX: Tenths? = nil,
+        defaultY: Tenths? = nil,
+        relativeX: Tenths? = nil,
+        relativeY: Tenths? = nil
+    ) {
+        self.defaultX = defaultX
+        self.defaultY = defaultY
+        self.relativeX = relativeX
+        self.relativeY = relativeY
+    }
 }
 
 extension Position: Equatable { }

--- a/Sources/MusicXML/Complex Types/Stem.swift
+++ b/Sources/MusicXML/Complex Types/Stem.swift
@@ -11,15 +11,33 @@
 /// relative-y that would flip a stem instead of shortening it are ignored. A stem element
 /// associated with a rest refers to a stemlet.
 public struct Stem {
+
+    // MARK: - Instance Properties
+
     public let value: StemValue
     public let position: Position
     public let color: Color?
+}
+
+extension Stem {
+
+    // MARK: Initializers
 
     public init(_ value: StemValue, position: Position = Position(), color: Color? = nil) {
         self.value = value
         self.position = position
         self.color = color
     }
+}
+
+extension Stem {
+
+    // MARK: Type Properties
+
+    public static let up = Stem(.up)
+    public static let down = Stem(.down)
+    public static let double = Stem(.double)
+    public static let none = Stem(.none)
 }
 
 extension Stem: Equatable { }

--- a/Sources/MusicXML/Complex Types/Stem.swift
+++ b/Sources/MusicXML/Complex Types/Stem.swift
@@ -11,9 +11,15 @@
 /// relative-y that would flip a stem instead of shortening it are ignored. A stem element
 /// associated with a rest refers to a stemlet.
 public struct Stem {
-    public var value: StemValue
-    public var position: Position = Position()
-    public var color: Color?
+    public let value: StemValue
+    public let position: Position
+    public let color: Color?
+
+    public init(_ value: StemValue, position: Position = Position(), color: Color? = nil) {
+        self.value = value
+        self.position = position
+        self.color = color
+    }
 }
 
 extension Stem: Equatable { }

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -177,7 +177,7 @@ class NoteTests: XCTestCase {
             position: Position(defaultX: 368.91, defaultY: 0),
             voice: "1",
             type: NoteType(value: .sixteenth),
-            stem: Stem(value: .down),
+            stem: Stem(.down),
             beams: [
                 Beam(value: .begin, number: .one),
                 Beam(value: .begin, number: .two)
@@ -219,7 +219,7 @@ class NoteTests: XCTestCase {
             position: Position(defaultX: 483.50, defaultY: -25.00),
             voice: "1",
             type: NoteType(value: .quarter),
-            stem: Stem(value: .up),
+            stem: Stem(.up),
             notations: Notations(values: [
                 .tied(Tied(type: .stop)),
                 .tied(Tied(type: .start))
@@ -260,7 +260,7 @@ class NoteTests: XCTestCase {
             instrument: Instrument(id: "P1-X2"),
             voice: "1",
             type: NoteType(value: .eighth),
-            stem: Stem(value: .down, position: Position(defaultY: -70)),
+            stem: Stem(.down, position: Position(defaultY: -70)),
             beams: [Beam(value: .begin, number: .one)]
         )
         XCTAssertEqual(decoded, expected)

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -177,7 +177,7 @@ class NoteTests: XCTestCase {
             position: Position(defaultX: 368.91, defaultY: 0),
             voice: "1",
             type: NoteType(value: .sixteenth),
-            stem: Stem(.down),
+            stem: .down,
             beams: [
                 Beam(value: .begin, number: .one),
                 Beam(value: .begin, number: .two)
@@ -219,7 +219,7 @@ class NoteTests: XCTestCase {
             position: Position(defaultX: 483.50, defaultY: -25.00),
             voice: "1",
             type: NoteType(value: .quarter),
-            stem: Stem(.up),
+            stem: .up,
             notations: Notations(values: [
                 .tied(Tied(type: .stop)),
                 .tied(Tied(type: .start))

--- a/Tests/MusicXMLTests/Initializers/PartWiseInitializerTests.swift
+++ b/Tests/MusicXMLTests/Initializers/PartWiseInitializerTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-// Do not use @testable
 import MusicXML
 
 class PartWiseInitializerTests: XCTestCase {
@@ -67,7 +66,7 @@ class PartWiseInitializerTests: XCTestCase {
                         position: Position(defaultX: 10, defaultY: -45),
                         voice: "1",
                         type: NoteType(value: .half),
-                        stem: Stem(value: .up)
+                        stem: .up
                     )
                 ),
             ]


### PR DESCRIPTION
With a nod toward #103, this PR modifies the `Stem` initializer by removing the attribute label for the `value` property.

Thus, to create a `Stem` value, you do this:

```Swift
let stem = Stem(.up)
```

as opposed to:

```Swift
let stem = Stem(value: .up)
```

I think this is a little cleaner and makes it more apparent that the `value` is the underlying type.