### PR TITLE
Create Sourcery stencil for autogenerating initializers and add all initializers to complex types

### DIFF
--- a/Sources/MusicXML/Complex Types/Accidental.swift
+++ b/Sources/MusicXML/Complex Types/Accidental.swift
@@ -13,17 +13,28 @@ public struct Accidental {
 
     // MARK: - Attributes
     
-    public var cautionary: Bool?
-    public var editorial: Bool?
-    public var parentheses: Bool?
-    public var bracket: Bool?
-    public var size: SymbolSize?
-    public var position: Position?
-    public var printStyle: PrintStyle?
+    public let cautionary: Bool?
+    public let editorial: Bool?
+    public let parentheses: Bool?
+    public let bracket: Bool?
+    public let size: SymbolSize?
+    public let position: Position?
+    public let printStyle: PrintStyle?
 
     // MARK: - Value
 
-    public var value: AccidentalValue
+    public let value: AccidentalValue
+
+    public init(cautionary: Bool? = nil, editorial: Bool? = nil, parentheses: Bool? = nil, bracket: Bool? = nil, size: SymbolSize? = nil, position: Position? = nil, printStyle: PrintStyle? = nil, value: AccidentalValue) {
+        self.cautionary = cautionary
+        self.editorial = editorial
+        self.parentheses = parentheses
+        self.bracket = bracket
+        self.size = size
+        self.position = position
+        self.printStyle = printStyle
+        self.value = value
+    }
 }
 
 extension Accidental: Equatable { }

--- a/Sources/MusicXML/Complex Types/AccidentalMark.swift
+++ b/Sources/MusicXML/Complex Types/AccidentalMark.swift
@@ -18,6 +18,13 @@ public struct AccidentalMark {
     public var placement: AboveBelow?
     public var position: Position?
     public var printStyle: PrintStyle?
+
+    public init(value: AccidentalValue, placement: AboveBelow? = nil, position: Position? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.placement = placement
+        self.position = position
+        self.printStyle = printStyle
+    }
 }
 
 extension AccidentalMark: Equatable { }

--- a/Sources/MusicXML/Complex Types/AccidentalText.swift
+++ b/Sources/MusicXML/Complex Types/AccidentalText.swift
@@ -28,6 +28,29 @@ public struct AccidentalText {
     public let lineHeight: NumberOrNormal?
     public let dir: TextDirection?
     public let enclosureShape: EnclosureShape?
+
+    public init(justify: LeftCenterRight? = nil, defaultX: Double? = nil, defaultY: Double? = nil, relativeX: Double? = nil, relativeY: Double? = nil, fontFamily: CommaSeparatedText? = nil, fontSize: FontSize? = nil, fontStyle: FontStyle? = nil, fontWeight: FontWeight? = nil, color: Color? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil, underline: Int? = nil, overline: Int? = nil, lineThrough: Int? = nil, rotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, lineHeight: NumberOrNormal? = nil, dir: TextDirection? = nil, enclosureShape: EnclosureShape? = nil) {
+        self.justify = justify
+        self.defaultX = defaultX
+        self.defaultY = defaultY
+        self.relativeX = relativeX
+        self.relativeY = relativeY
+        self.fontFamily = fontFamily
+        self.fontSize = fontSize
+        self.fontStyle = fontStyle
+        self.fontWeight = fontWeight
+        self.color = color
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+        self.underline = underline
+        self.overline = overline
+        self.lineThrough = lineThrough
+        self.rotation = rotation
+        self.letterSpacing = letterSpacing
+        self.lineHeight = lineHeight
+        self.dir = dir
+        self.enclosureShape = enclosureShape
+    }
 }
 
 extension AccidentalText: Equatable { }

--- a/Sources/MusicXML/Complex Types/Accord.swift
+++ b/Sources/MusicXML/Complex Types/Accord.swift
@@ -13,6 +13,13 @@ public struct Accord {
     public let tuningAlter: Double? // semitones
     public let tuningOctave: Int? // octaves
 
+
+    public init(string: Int, tuningStep: Step, tuningAlter: Double? = nil, tuningOctave: Int? = nil) {
+        self.string = string
+        self.tuningStep = tuningStep
+        self.tuningAlter = tuningAlter
+        self.tuningOctave = tuningOctave
+    }
 }
 
 extension Accord: Equatable { }

--- a/Sources/MusicXML/Complex Types/AccordionRegistration.swift
+++ b/Sources/MusicXML/Complex Types/AccordionRegistration.swift
@@ -15,6 +15,13 @@ public struct AccordionRegistration {
     public let printStyle: PrintStyle?
     public let hAlign: LeftCenterRight?
     public let vAlaign: VAlign?
+
+    public init(position: Position? = nil, printStyle: PrintStyle? = nil, hAlign: LeftCenterRight? = nil, vAlaign: VAlign? = nil) {
+        self.position = position
+        self.printStyle = printStyle
+        self.hAlign = hAlign
+        self.vAlaign = vAlaign
+    }
 }
 
 extension AccordionRegistration: Equatable { }

--- a/Sources/MusicXML/Complex Types/Appearance.swift
+++ b/Sources/MusicXML/Complex Types/Appearance.swift
@@ -14,6 +14,12 @@ public struct Appearance {
     public let noteSize: NoteSizeType?
     public let distance: Distance?
     // TODO: other-appearance?
+
+    public init(lineWidth: LineWidth? = nil, noteSize: NoteSizeType? = nil, distance: Distance? = nil) {
+        self.lineWidth = lineWidth
+        self.noteSize = noteSize
+        self.distance = distance
+    }
 }
 
 extension Appearance: Equatable { }

--- a/Sources/MusicXML/Complex Types/Arpeggiate.swift
+++ b/Sources/MusicXML/Complex Types/Arpeggiate.swift
@@ -15,6 +15,14 @@ public struct Arpeggiate {
     public var position: Position?
     public var placement: AboveBelow?
     public var color: Color?
+
+    public init(number: Int? = nil, direction: UpDown? = nil, position: Position? = nil, placement: AboveBelow? = nil, color: Color? = nil) {
+        self.number = number
+        self.direction = direction
+        self.position = position
+        self.placement = placement
+        self.color = color
+    }
 }
 
 extension Arpeggiate: Equatable { }

--- a/Sources/MusicXML/Complex Types/Arrow.swift
+++ b/Sources/MusicXML/Complex Types/Arrow.swift
@@ -13,6 +13,13 @@ public struct Arrow {
     public let position: Position?
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(kind: Kind, position: Position? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.kind = kind
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Arrow {

--- a/Sources/MusicXML/Complex Types/Articulations.swift
+++ b/Sources/MusicXML/Complex Types/Articulations.swift
@@ -7,6 +7,10 @@
 
 public struct Articulations {
     let values: [Articulation]
+
+    public init(values: [Articulation]) {
+        self.values = values
+    }
 }
 
 extension Articulations: Equatable { }

--- a/Sources/MusicXML/Complex Types/Attributes.swift
+++ b/Sources/MusicXML/Complex Types/Attributes.swift
@@ -26,18 +26,45 @@
 /// attributes are changed mid-measure, it affects the music in score order, not in MusicXML
 /// document order.
 public struct Attributes {
-    public var footnote: FormattedText?
-    public var level: Level?
-    public var divisions: Int?
-    public var keys: [Key]?
-    public var times: [Time]?
-    public var staves: Int?
-    public var partSymbol: PartSymbol?
-    public var instruments: Int?
-    public var clefs: [Clef]?
-    public var staffDetails: [StaffDetails]?
-    public var transpose: [Transpose]?
-    public var measureStyles: [MeasureStyle]?
+    public let footnote: FormattedText?
+    public let level: Level?
+    public let divisions: Int?
+    public let keys: [Key]?
+    public let times: [Time]?
+    public let staves: Int?
+    public let partSymbol: PartSymbol?
+    public let instruments: Int?
+    public let clefs: [Clef]?
+    public let staffDetails: [StaffDetails]?
+    public let transpose: [Transpose]?
+    public let measureStyles: [MeasureStyle]?
+
+    public init(
+        footnote: FormattedText? = nil,
+        level: Level? = nil,
+        divisions: Int? = nil,
+        keys: [Key]? = nil,
+        times: [Time]? = nil,
+        staves: Int? = nil,
+        partSymbol: PartSymbol? = nil,
+        instruments: Int? = nil,
+        clefs: [Clef]? = nil,
+        staffDetails: [StaffDetails]? = nil,
+        transpose: [Transpose]? = nil,
+        measureStyles: [MeasureStyle]? = nil) {
+        self.footnote = footnote
+        self.level = level
+        self.divisions = divisions
+        self.keys = keys
+        self.times = times
+        self.staves = staves
+        self.partSymbol = partSymbol
+        self.instruments = instruments
+        self.clefs = clefs
+        self.staffDetails = staffDetails
+        self.transpose = transpose
+        self.measureStyles = measureStyles
+    }
 }
 
 extension Attributes: Equatable { }

--- a/Sources/MusicXML/Complex Types/Backup.swift
+++ b/Sources/MusicXML/Complex Types/Backup.swift
@@ -16,4 +16,9 @@ public struct Backup: Codable, Equatable {
 
     public var duration: Int
     public var editorial: Editorial?
+
+    public init(duration: Int, editorial: Editorial? = nil) {
+        self.duration = duration
+        self.editorial = editorial
+    }
 }

--- a/Sources/MusicXML/Complex Types/BarStyleColor.swift
+++ b/Sources/MusicXML/Complex Types/BarStyleColor.swift
@@ -9,6 +9,11 @@
 public struct BarStyleColor {
     public var value: BarStyle
     public var color: Color?
+
+    public init(value: BarStyle, color: Color? = nil) {
+        self.value = value
+        self.color = color
+    }
 }
 
 extension BarStyleColor: Equatable { }

--- a/Sources/MusicXML/Complex Types/Barline.swift
+++ b/Sources/MusicXML/Complex Types/Barline.swift
@@ -70,6 +70,19 @@ public struct Barline {
     public var fermata: Fermata?
     public var ending: Ending?
     public var `repeat`: Repeat?
+
+    public init(location: RightLeftMiddle? = nil, segno: EmptyPrintStyleAlign? = nil, coda: EmptyPrintStyleAlign? = nil, divisions: Int? = nil, barStyle: BarStyleColor? = nil, editorial: Editorial? = nil, wavyLine: WavyLine? = nil, fermata: Fermata? = nil, ending: Ending? = nil, `repeat`: Repeat? = nil) {
+        self.location = location
+        self.segno = segno
+        self.coda = coda
+        self.divisions = divisions
+        self.barStyle = barStyle
+        self.editorial = editorial
+        self.wavyLine = wavyLine
+        self.fermata = fermata
+        self.ending = ending
+        self.`repeat` = `repeat`
+    }
 }
 
 extension Barline: Equatable { }

--- a/Sources/MusicXML/Complex Types/Barre.swift
+++ b/Sources/MusicXML/Complex Types/Barre.swift
@@ -11,6 +11,11 @@
 public struct Barre {
     public let type: StartStop
     public let color: Color
+
+    public init(type: StartStop, color: Color) {
+        self.type = type
+        self.color = color
+    }
 }
 
 extension Barre: Equatable { }

--- a/Sources/MusicXML/Complex Types/Bass.swift
+++ b/Sources/MusicXML/Complex Types/Bass.swift
@@ -11,4 +11,9 @@
 public struct Bass: Codable, Equatable {
     public let bassStep: BassStep
     public let bassAlter: BassAlter?
+
+    public init(bassStep: BassStep, bassAlter: BassAlter? = nil) {
+        self.bassStep = bassStep
+        self.bassAlter = bassAlter
+    }
 }

--- a/Sources/MusicXML/Complex Types/BassAlter.swift
+++ b/Sources/MusicXML/Complex Types/BassAlter.swift
@@ -12,6 +12,13 @@ public struct BassAlter {
     public let printObject: Bool?
     public let printStyle: PrintStyle?
     public let location: LeftRight?
+
+    public init(value: Double, printObject: Bool? = nil, printStyle: PrintStyle? = nil, location: LeftRight? = nil) {
+        self.value = value
+        self.printObject = printObject
+        self.printStyle = printStyle
+        self.location = location
+    }
 }
 
 extension BassAlter: Equatable { }

--- a/Sources/MusicXML/Complex Types/BassStep.swift
+++ b/Sources/MusicXML/Complex Types/BassStep.swift
@@ -15,6 +15,12 @@ public struct BassStep {
     /// contents.
     public let text: String?
     public let printStyle: PrintStyle?
+
+    public init(value: Step, text: String? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.text = text
+        self.printStyle = printStyle
+    }
 }
 
 extension BassStep: Equatable { }

--- a/Sources/MusicXML/Complex Types/Beam.swift
+++ b/Sources/MusicXML/Complex Types/Beam.swift
@@ -17,6 +17,14 @@ public struct Beam {
     public var repeater: Bool?
     public var fan: Fan?
     public var color: Color?
+
+    public init(value: BeamValue, number: BeamLevel? = nil, repeater: Bool? = nil, fan: Fan? = nil, color: Color? = nil) {
+        self.value = value
+        self.number = number
+        self.repeater = repeater
+        self.fan = fan
+        self.color = color
+    }
 }
 
 extension Beam: Equatable { }

--- a/Sources/MusicXML/Complex Types/BeatRepeat.swift
+++ b/Sources/MusicXML/Complex Types/BeatRepeat.swift
@@ -14,6 +14,12 @@ public struct BeatRepeat {
     public let type: StartStop
     public let slashes: Int
     public let useDots: Bool
+
+    public init(type: StartStop, slashes: Int, useDots: Bool) {
+        self.type = type
+        self.slashes = slashes
+        self.useDots = useDots
+    }
 }
 
 extension BeatRepeat: Equatable { }

--- a/Sources/MusicXML/Complex Types/Beater.swift
+++ b/Sources/MusicXML/Complex Types/Beater.swift
@@ -8,6 +8,11 @@
 public struct Beater {
     public let value: BeaterValue
     public let tip: TipDirection?
+
+    public init(value: BeaterValue, tip: TipDirection? = nil) {
+        self.value = value
+        self.tip = tip
+    }
 }
 
 extension Beater: Equatable { }

--- a/Sources/MusicXML/Complex Types/Bend.swift
+++ b/Sources/MusicXML/Complex Types/Bend.swift
@@ -22,6 +22,17 @@ public struct Bend {
     public let bendAlter: Double?
     public let prependOrRelease: PreBendOrRelease?
     public let withBar: PlacementText?
+
+    public init(printStyle: PrintStyle? = nil, accelerate: Bool? = nil, beats: Bool? = nil, firstBeat: Double? = nil, lastBeat: Double? = nil, bendAlter: Double? = nil, prependOrRelease: PreBendOrRelease? = nil, withBar: PlacementText? = nil) {
+        self.printStyle = printStyle
+        self.accelerate = accelerate
+        self.beats = beats
+        self.firstBeat = firstBeat
+        self.lastBeat = lastBeat
+        self.bendAlter = bendAlter
+        self.prependOrRelease = prependOrRelease
+        self.withBar = withBar
+    }
 }
 
 extension Bend {

--- a/Sources/MusicXML/Complex Types/BendSound.swift
+++ b/Sources/MusicXML/Complex Types/BendSound.swift
@@ -18,10 +18,17 @@
 // >     first-beat = "25"
 // >     last-beat = "75"
 public struct BendSound {
-    public let accelerate: Bool = false
-    public let beats: Int = 4
-    public let firstBeat: Int = 25
-    public let lastBeat: Int = 75
+    public let accelerate: Bool
+    public let beats: Int
+    public let firstBeat: Int
+    public let lastBeat: Int
+
+    public init(accelerate: Bool = false, beats: Int = 4, firstBeat: Int = 25, lastBeat: Int = 75) {
+        self.accelerate = accelerate
+        self.beats = beats
+        self.firstBeat = firstBeat
+        self.lastBeat = lastBeat
+    }
 }
 
 extension BendSound: Equatable { }

--- a/Sources/MusicXML/Complex Types/Bezier.swift
+++ b/Sources/MusicXML/Complex Types/Bezier.swift
@@ -24,6 +24,15 @@ public struct Bezier {
     public let bezierY2: Int
     public let bezierOffset: Int
     public let bezierOffset2: Int
+
+    public init(bezierX: Int, bezierY: Int, bezierX2: Int, bezierY2: Int, bezierOffset: Int, bezierOffset2: Int) {
+        self.bezierX = bezierX
+        self.bezierY = bezierY
+        self.bezierX2 = bezierX2
+        self.bezierY2 = bezierY2
+        self.bezierOffset = bezierOffset
+        self.bezierOffset2 = bezierOffset2
+    }
 }
 
 extension Bezier: Equatable { }

--- a/Sources/MusicXML/Complex Types/Bookmark.swift
+++ b/Sources/MusicXML/Complex Types/Bookmark.swift
@@ -11,6 +11,13 @@ public struct Bookmark {
     public let name: String?
     public let element: String?
     public let position: Int?
+
+    public init(id: String, name: String? = nil, element: String? = nil, position: Int? = nil) {
+        self.id = id
+        self.name = name
+        self.element = element
+        self.position = position
+    }
 }
 
 extension Bookmark: Equatable { }

--- a/Sources/MusicXML/Complex Types/Bracket.swift
+++ b/Sources/MusicXML/Complex Types/Bracket.swift
@@ -18,6 +18,18 @@ public struct Bracket {
     public let spaceLength: Tenths?
     public let position: Position?
     public let color: Color?
+
+    public init(type: StartStopContinue, number: Int? = nil, lineEnd: LineEnd, endLength: Tenths? = nil, lineType: LineType? = nil, dashLength: Tenths? = nil, spaceLength: Tenths? = nil, position: Position? = nil, color: Color? = nil) {
+        self.type = type
+        self.number = number
+        self.lineEnd = lineEnd
+        self.endLength = endLength
+        self.lineType = lineType
+        self.dashLength = dashLength
+        self.spaceLength = spaceLength
+        self.position = position
+        self.color = color
+    }
 }
 
 extension Bracket: Equatable { }

--- a/Sources/MusicXML/Complex Types/BreathMark.swift
+++ b/Sources/MusicXML/Complex Types/BreathMark.swift
@@ -11,6 +11,13 @@ public struct BreathMark {
     public let position: Position
     public let printStyle: PrintStyle
     public let placement: AboveBelow
+
+    public init(value: BreathMarkValue, position: Position, printStyle: PrintStyle, placement: AboveBelow) {
+        self.value = value
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension BreathMark: Equatable { }

--- a/Sources/MusicXML/Complex Types/Cancel.swift
+++ b/Sources/MusicXML/Complex Types/Cancel.swift
@@ -12,6 +12,11 @@
 public struct Cancel {
     public let fifths: Int
     public let location: CancelLocation
+
+    public init(fifths: Int, location: CancelLocation) {
+        self.fifths = fifths
+        self.location = location
+    }
 }
 
 extension Cancel: Equatable { }

--- a/Sources/MusicXML/Complex Types/Clef.swift
+++ b/Sources/MusicXML/Complex Types/Clef.swift
@@ -14,18 +14,30 @@ public struct Clef {
 
     // MARK: - Attributes
 
-    public var number: Int?
-    public var additional: Bool?
-    public var size: SymbolSize?
-    public var afterBarline: Bool?
-    public var printStyle: PrintStyle?
-    public var printObject: Bool?
+    public let number: Int?
+    public let additional: Bool?
+    public let size: SymbolSize?
+    public let afterBarline: Bool?
+    public let printStyle: PrintStyle?
+    public let printObject: Bool?
 
     // MARK: - Elements
 
-    public var sign: ClefSign
-    public var line: Int?
-    public var clefOctaveChange: Int?
+    public let sign: ClefSign
+    public let line: Int?
+    public let clefOctaveChange: Int?
+
+    public init(number: Int? = nil, additional: Bool? = nil, size: SymbolSize? = nil, afterBarline: Bool? = nil, printStyle: PrintStyle? = nil, printObject: Bool? = nil, sign: ClefSign, line: Int? = nil, clefOctaveChange: Int? = nil) {
+        self.number = number
+        self.additional = additional
+        self.size = size
+        self.afterBarline = afterBarline
+        self.printStyle = printStyle
+        self.printObject = printObject
+        self.sign = sign
+        self.line = line
+        self.clefOctaveChange = clefOctaveChange
+    }
 }
 
 extension Clef: Equatable { }

--- a/Sources/MusicXML/Complex Types/Creator.swift
+++ b/Sources/MusicXML/Complex Types/Creator.swift
@@ -23,6 +23,11 @@ public struct Creator {
         self.value = value
         self.type = type
     }
+
+    public init(value: String, type: String? = nil) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension Creator: Equatable { }

--- a/Sources/MusicXML/Complex Types/Credit.swift
+++ b/Sources/MusicXML/Complex Types/Credit.swift
@@ -38,6 +38,13 @@ public struct Credit {
     /// compressed MusicXML file, the link is relative to the  root folder of the zip file.
     public let link: [Link]?
     public let bookmarks: [Bookmark]?
+
+    public init(page: Int? = nil, types: [String]? = nil, link: [Link]? = nil, bookmarks: [Bookmark]? = nil) {
+        self.page = page
+        self.types = types
+        self.link = link
+        self.bookmarks = bookmarks
+    }
 }
 
 extension Credit {
@@ -46,6 +53,12 @@ extension Credit {
         public let words: FormattedText
         public let links: [Link]
         public let bookmark: [Bookmark]
+
+        public init(words: FormattedText, links: [Link], bookmark: [Bookmark]) {
+            self.words = words
+            self.links = links
+            self.bookmark = bookmark
+        }
     }
 
     #warning("FIXME: Establish correct model for Credit.Kind.words")

--- a/Sources/MusicXML/Complex Types/DashedFormatting.swift
+++ b/Sources/MusicXML/Complex Types/DashedFormatting.swift
@@ -12,6 +12,11 @@
 public struct DashedFormatting {
     public let dashLength: Tenths
     public let spaceLength: Tenths
+
+    public init(dashLength: Tenths, spaceLength: Tenths) {
+        self.dashLength = dashLength
+        self.spaceLength = spaceLength
+    }
 }
 
 extension DashedFormatting: Equatable { }

--- a/Sources/MusicXML/Complex Types/Dashes.swift
+++ b/Sources/MusicXML/Complex Types/Dashes.swift
@@ -9,6 +9,11 @@
 public struct Dashes {
     public let type: StartStopContinue
     public let dashedFormatting: DashedFormatting
+
+    public init(type: StartStopContinue, dashedFormatting: DashedFormatting) {
+        self.type = type
+        self.dashedFormatting = dashedFormatting
+    }
 }
 
 extension Dashes: Equatable { }

--- a/Sources/MusicXML/Complex Types/Defaults.swift
+++ b/Sources/MusicXML/Complex Types/Defaults.swift
@@ -16,9 +16,24 @@ public struct Defaults: Codable, Equatable {
     public let wordFont: EmptyFont?
     public let lyricFonts: [LyricFont]
     public let lyricLanguages: [LyricLanguage]
+
+    public init(scaling: Scaling? = nil, pageLayout: PageLayout? = nil, systemLayout: SystemLayout? = nil, staffLayout: StaffLayout? = nil, appearance: Appearance? = nil, musicFont: EmptyFont? = nil, wordFont: EmptyFont? = nil, lyricFonts: [LyricFont], lyricLanguages: [LyricLanguage]) {
+        self.scaling = scaling
+        self.pageLayout = pageLayout
+        self.systemLayout = systemLayout
+        self.staffLayout = staffLayout
+        self.appearance = appearance
+        self.musicFont = musicFont
+        self.wordFont = wordFont
+        self.lyricFonts = lyricFonts
+        self.lyricLanguages = lyricLanguages
+    }
 }
 
 // FIXME: Redefine?
-public struct Scaling { }
+public struct Scaling {
+    public init() {
+    }
+ }
 extension Scaling: Equatable { }
 extension Scaling: Codable { }

--- a/Sources/MusicXML/Complex Types/Degree.swift
+++ b/Sources/MusicXML/Complex Types/Degree.swift
@@ -16,5 +16,12 @@ public struct Degree: Codable, Equatable {
     public let alter: DegreeAlter
     public let type: DegreeType
     public let printObject: Bool
+
+    public init(value: DegreeValue, alter: DegreeAlter, type: DegreeType, printObject: Bool) {
+        self.value = value
+        self.alter = alter
+        self.type = type
+        self.printObject = printObject
+    }
 }
 

--- a/Sources/MusicXML/Complex Types/DegreeAlter.swift
+++ b/Sources/MusicXML/Complex Types/DegreeAlter.swift
@@ -15,6 +15,12 @@ public struct DegreeAlter {
     public let value: Int
     public let printStyle: PrintStyle?
     public let plusMinus: Bool?
+
+    public init(value: Int, printStyle: PrintStyle? = nil, plusMinus: Bool? = nil) {
+        self.value = value
+        self.printStyle = printStyle
+        self.plusMinus = plusMinus
+    }
 }
 
 extension DegreeAlter: Equatable { }

--- a/Sources/MusicXML/Complex Types/DegreeType.swift
+++ b/Sources/MusicXML/Complex Types/DegreeType.swift
@@ -13,6 +13,12 @@ public struct DegreeType {
     let value: DegreeTypeValue
     let text: String?
     let printStyle: PrintStyle?
+
+    public init(value: DegreeTypeValue, text: String? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.text = text
+        self.printStyle = printStyle
+    }
 }
 
 extension DegreeType: Equatable { }

--- a/Sources/MusicXML/Complex Types/DegreeValue.swift
+++ b/Sources/MusicXML/Complex Types/DegreeValue.swift
@@ -15,6 +15,13 @@ public struct DegreeValue {
     public let symbol: DegreeSymbolValue?
     public let text: String?
     public let printStyle: PrintStyle?
+
+    public init(value: Int, symbol: DegreeSymbolValue? = nil, text: String? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.symbol = symbol
+        self.text = text
+        self.printStyle = printStyle
+    }
 }
 
 extension DegreeValue: Equatable { }

--- a/Sources/MusicXML/Complex Types/Direction.swift
+++ b/Sources/MusicXML/Complex Types/Direction.swift
@@ -12,9 +12,15 @@
 /// children, non-positional formatting attributes are carried over from the previous element by
 /// default.
 public struct Direction {
-    public var placement: AboveBelow?
-    public var directive: Bool?
-    public var directionType: DirectionType
+    public let placement: AboveBelow?
+    public let directive: Bool?
+    public let directionType: DirectionType
+
+    public init(placement: AboveBelow? = nil, directive: Bool? = nil, directionType: DirectionType) {
+        self.placement = placement
+        self.directive = directive
+        self.directionType = directionType
+    }
 }
 
 extension Direction: Equatable { }

--- a/Sources/MusicXML/Complex Types/Distance.swift
+++ b/Sources/MusicXML/Complex Types/Distance.swift
@@ -9,6 +9,11 @@
 public struct Distance {
     public let value: Tenths
     public let type: DistanceType
+
+    public init(value: Tenths, type: DistanceType) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension Distance: Equatable { }

--- a/Sources/MusicXML/Complex Types/Dynamics.swift
+++ b/Sources/MusicXML/Complex Types/Dynamics.swift
@@ -23,6 +23,14 @@ public struct Dynamics {
     public let placement: AboveBelow?
     public let textDecoration: TextDecoration?
     public let enclosure: EnclosureShape?
+
+    public init(values: [Dynamic], printStyleAlign: PrintStyleAlign? = nil, placement: AboveBelow? = nil, textDecoration: TextDecoration? = nil, enclosure: EnclosureShape? = nil) {
+        self.values = values
+        self.printStyleAlign = printStyleAlign
+        self.placement = placement
+        self.textDecoration = textDecoration
+        self.enclosure = enclosure
+    }
 }
 
 

--- a/Sources/MusicXML/Complex Types/Editorial.swift
+++ b/Sources/MusicXML/Complex Types/Editorial.swift
@@ -14,6 +14,11 @@
 public struct Editorial {
     public let footnote: FormattedText?
     public let level: Level?
+
+    public init(footnote: FormattedText? = nil, level: Level? = nil) {
+        self.footnote = footnote
+        self.level = level
+    }
 }
 
 extension Editorial: Equatable { }

--- a/Sources/MusicXML/Complex Types/EditorialVoice.swift
+++ b/Sources/MusicXML/Complex Types/EditorialVoice.swift
@@ -10,6 +10,12 @@ public struct EditorialVoice {
     public let footnote: FormattedText?
     public let level: Level?
     public let voice: Int?
+
+    public init(footnote: FormattedText? = nil, level: Level? = nil, voice: Int? = nil) {
+        self.footnote = footnote
+        self.level = level
+        self.voice = voice
+    }
 }
 
 extension EditorialVoice: Equatable { }

--- a/Sources/MusicXML/Complex Types/Empty.swift
+++ b/Sources/MusicXML/Complex Types/Empty.swift
@@ -5,7 +5,10 @@
 //  Created by James Bean on 5/15/19.
 //
 
-public struct Empty { }
+public struct Empty {
+    public init() {
+    }
+ }
 
 extension Empty: Equatable { }
 extension Empty: Codable { }

--- a/Sources/MusicXML/Complex Types/EmptyFont.swift
+++ b/Sources/MusicXML/Complex Types/EmptyFont.swift
@@ -8,6 +8,10 @@
 /// The empty-font type represents an empty element with font attributes.
 public struct EmptyFont {
     public let font: Font?
+
+    public init(font: Font? = nil) {
+        self.font = font
+    }
 }
 
 extension EmptyFont: Equatable { }

--- a/Sources/MusicXML/Complex Types/EmptyLine.swift
+++ b/Sources/MusicXML/Complex Types/EmptyLine.swift
@@ -14,6 +14,15 @@ public struct EmptyLine {
     public var position: Position?
     public var printStyle: PrintStyle?
     public var placement: AboveBelow?
+
+    public init(lineShape: LineShape? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, position: Position? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.lineShape = lineShape
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension EmptyLine: Equatable { }

--- a/Sources/MusicXML/Complex Types/EmptyPlacement.swift
+++ b/Sources/MusicXML/Complex Types/EmptyPlacement.swift
@@ -10,6 +10,12 @@ public struct EmptyPlacement {
     public var position: Position?
     public var printStyle: PrintStyle?
     public var placement: AboveBelow?
+
+    public init(position: Position? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension EmptyPlacement: Equatable { }

--- a/Sources/MusicXML/Complex Types/EmptyPrintObjectStyleAlign.swift
+++ b/Sources/MusicXML/Complex Types/EmptyPrintObjectStyleAlign.swift
@@ -10,6 +10,11 @@
 public struct EmptyPrintObjectStyleAlign {
     public let printObject: Bool?
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(printObject: Bool? = nil, printStyleAlign: PrintStyleAlign? = nil) {
+        self.printObject = printObject
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension EmptyPrintObjectStyleAlign: Equatable { }

--- a/Sources/MusicXML/Complex Types/EmptyPrintStyleAlign.swift
+++ b/Sources/MusicXML/Complex Types/EmptyPrintStyleAlign.swift
@@ -11,6 +11,12 @@ public struct EmptyPrintStyleAlign {
     public let printStyle: PrintStyle?
     public let hAlign: LeftCenterRight?
     public let vAlign: VAlign?
+
+    public init(printStyle: PrintStyle? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil) {
+        self.printStyle = printStyle
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+    }
 }
 
 extension EmptyPrintStyleAlign: Equatable { }

--- a/Sources/MusicXML/Complex Types/EmptyTrillSound.swift
+++ b/Sources/MusicXML/Complex Types/EmptyTrillSound.swift
@@ -11,6 +11,12 @@ public struct EmptyTrillSound {
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
     public let trillSound: TrillSound
+
+    public init(printStyle: PrintStyle? = nil, placement: AboveBelow? = nil, trillSound: TrillSound) {
+        self.printStyle = printStyle
+        self.placement = placement
+        self.trillSound = trillSound
+    }
 }
 
 extension EmptyTrillSound: Equatable { }

--- a/Sources/MusicXML/Complex Types/Encoding.swift
+++ b/Sources/MusicXML/Complex Types/Encoding.swift
@@ -22,6 +22,10 @@ public struct Encoding {
     }
 
     public let values: [Kind]
+
+    public init(values: [Kind]) {
+        self.values = values
+    }
 }
 
 extension Encoding.Kind: Equatable { }

--- a/Sources/MusicXML/Complex Types/Ending.swift
+++ b/Sources/MusicXML/Complex Types/Ending.swift
@@ -24,6 +24,17 @@ public struct Ending {
     public let endLength: Tenths?
     public let textX: Tenths?
     public let textY: Tenths?
+
+    public init(value: EndingNumber, number: [Int], type: StartStopContinue, printObject: Bool? = nil, printStyle: PrintStyle? = nil, endLength: Tenths? = nil, textX: Tenths? = nil, textY: Tenths? = nil) {
+        self.value = value
+        self.number = number
+        self.type = type
+        self.printObject = printObject
+        self.printStyle = printStyle
+        self.endLength = endLength
+        self.textX = textX
+        self.textY = textY
+    }
 }
 
 extension Ending: Equatable { }

--- a/Sources/MusicXML/Complex Types/Extend.swift
+++ b/Sources/MusicXML/Complex Types/Extend.swift
@@ -11,6 +11,11 @@
 public struct Extend {
     public let type: StartStopContinue?
     public let printStyle: PrintStyle?
+
+    public init(type: StartStopContinue? = nil, printStyle: PrintStyle? = nil) {
+        self.type = type
+        self.printStyle = printStyle
+    }
 }
 
 extension Extend: Equatable { }

--- a/Sources/MusicXML/Complex Types/Feature.swift
+++ b/Sources/MusicXML/Complex Types/Feature.swift
@@ -11,6 +11,11 @@
 public struct Feature {
     public let value: String
     public let type: String?
+
+    public init(value: String, type: String? = nil) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension Feature: Equatable { }

--- a/Sources/MusicXML/Complex Types/Fermata.swift
+++ b/Sources/MusicXML/Complex Types/Fermata.swift
@@ -17,6 +17,12 @@ public struct Fermata {
 
     public var type: UprightInverted?
     public var printStyle: PrintStyle?
+
+    public init(value: FermataShape, type: UprightInverted? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.type = type
+        self.printStyle = printStyle
+    }
 }
 
 extension Fermata: Equatable { }

--- a/Sources/MusicXML/Complex Types/Figure.swift
+++ b/Sources/MusicXML/Complex Types/Figure.swift
@@ -24,6 +24,13 @@ public struct Figure {
     /// The extend type represents lyric word extension / melisma lines as well as figured bass
     /// extensions.
     public let extend: Extend?
+
+    public init(prefix: StyleText? = nil, figureNumber: StyleText? = nil, suffix: StyleText? = nil, extend: Extend? = nil) {
+        self.prefix = prefix
+        self.figureNumber = figureNumber
+        self.suffix = suffix
+        self.extend = extend
+    }
 }
 
 extension Figure: Equatable { }

--- a/Sources/MusicXML/Complex Types/FiguredBass.swift
+++ b/Sources/MusicXML/Complex Types/FiguredBass.swift
@@ -15,7 +15,7 @@ public struct FiguredBass {
     public let printout: Printout
 
     // > The value of parentheses is "no" if not present.
-    public let parentheses: Bool = false
+    public let parentheses: Bool
 
     /// The figure type represents a single figure within a figured-bass element.
     public let figures: [Figure] // NonEmpty
@@ -33,6 +33,16 @@ public struct FiguredBass {
 
     /// The level type is used to specify editorial information for different MusicXML elements.
     public let level: Level?
+
+    public init(printStyle: PrintStyle, printout: Printout, parentheses: Bool = false, figures: [Figure], duration: Int? = nil, footnote: FormattedText? = nil, level: Level? = nil) {
+        self.printStyle = printStyle
+        self.printout = printout
+        self.parentheses = parentheses
+        self.figures = figures
+        self.duration = duration
+        self.footnote = footnote
+        self.level = level
+    }
 }
 
 extension FiguredBass: Equatable { }

--- a/Sources/MusicXML/Complex Types/Fingering.swift
+++ b/Sources/MusicXML/Complex Types/Fingering.swift
@@ -14,6 +14,13 @@ public struct Fingering {
     public let alternate: Bool
     public let printStyle: PrintStyle
     public let placement: AboveBelow
+
+    public init(substitution: Bool, alternate: Bool, printStyle: PrintStyle, placement: AboveBelow) {
+        self.substitution = substitution
+        self.alternate = alternate
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Fingering: Equatable { }

--- a/Sources/MusicXML/Complex Types/FirstFret.swift
+++ b/Sources/MusicXML/Complex Types/FirstFret.swift
@@ -11,6 +11,12 @@ public struct FirstFret {
     public let value: Int
     public let text: String?
     public let location: LeftRight?
+
+    public init(value: Int, text: String? = nil, location: LeftRight? = nil) {
+        self.value = value
+        self.text = text
+        self.location = location
+    }
 }
 
 extension FirstFret: Equatable { }

--- a/Sources/MusicXML/Complex Types/Font.swift
+++ b/Sources/MusicXML/Complex Types/Font.swift
@@ -20,6 +20,13 @@ public struct Font {
     public let style: FontStyle
     public let size: FontSize
     public let weight: FontWeight
+
+    public init(family: CommaSeparatedText, style: FontStyle, size: FontSize, weight: FontWeight) {
+        self.family = family
+        self.style = style
+        self.size = size
+        self.weight = weight
+    }
 }
 
 extension Font: Equatable { }

--- a/Sources/MusicXML/Complex Types/FormattedText.swift
+++ b/Sources/MusicXML/Complex Types/FormattedText.swift
@@ -20,6 +20,22 @@ public struct FormattedText {
     public let lineHeight: NumberOrNormal
     public let dir: TextDirection
     public let enclosure: EnclosureShape
+
+    public init(justify: LeftCenterRight, position: Position, printStyle: PrintStyle, hAlign: LeftCenterRight, vAlign: VAlign, underline: Int, overline: Int, lineThrough: Int, rotation: Double, letterSpacing: NumberOrNormal, lineHeight: NumberOrNormal, dir: TextDirection, enclosure: EnclosureShape) {
+        self.justify = justify
+        self.position = position
+        self.printStyle = printStyle
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+        self.underline = underline
+        self.overline = overline
+        self.lineThrough = lineThrough
+        self.rotation = rotation
+        self.letterSpacing = letterSpacing
+        self.lineHeight = lineHeight
+        self.dir = dir
+        self.enclosure = enclosure
+    }
 }
 
 extension FormattedText: Equatable { }

--- a/Sources/MusicXML/Complex Types/Forward.swift
+++ b/Sources/MusicXML/Complex Types/Forward.swift
@@ -22,6 +22,12 @@ public struct Forward {
     /// Staff assignment is only needed for music notated on multiple staves. Used by both notes
     /// and directions. Staff values are numbers, with 1 referring to the top-most staff in a part.
     public let staff: Int?
+
+    public init(duration: Int, editorialVoice: EditorialVoice? = nil, staff: Int? = nil) {
+        self.duration = duration
+        self.editorialVoice = editorialVoice
+        self.staff = staff
+    }
 }
 
 extension Forward: Equatable { }

--- a/Sources/MusicXML/Complex Types/Frame.swift
+++ b/Sources/MusicXML/Complex Types/Frame.swift
@@ -29,6 +29,20 @@ public struct Frame {
     /// The frame-note type represents each note included in the frame. An open string will have a
     /// fret value of 0, while a muted string will not be associated with a frame-note element.
     public let frameNote: [FrameNote] // NonEmpty
+
+    public init(position: Position? = nil, color: Color? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlignImage? = nil, height: Tenths? = nil, width: Tenths? = nil, unplayed: String, frameStrings: Int, frameFrets: Int, firstFret: FirstFret? = nil, frameNote: [FrameNote]) {
+        self.position = position
+        self.color = color
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+        self.height = height
+        self.width = width
+        self.unplayed = unplayed
+        self.frameStrings = frameStrings
+        self.frameFrets = frameFrets
+        self.firstFret = firstFret
+        self.frameNote = frameNote
+    }
 }
 
 extension Frame: Equatable { }

--- a/Sources/MusicXML/Complex Types/FrameNote.swift
+++ b/Sources/MusicXML/Complex Types/FrameNote.swift
@@ -12,6 +12,13 @@ public struct FrameNote {
     public let fret: Fret
     public let fingering: Fingering?
     public let barre: Barre?
+
+    public init(string: MusicXML.String, fret: Fret, fingering: Fingering? = nil, barre: Barre? = nil) {
+        self.string = string
+        self.fret = fret
+        self.fingering = fingering
+        self.barre = barre
+    }
 }
 
 extension FrameNote: Equatable { }

--- a/Sources/MusicXML/Complex Types/Fret.swift
+++ b/Sources/MusicXML/Complex Types/Fret.swift
@@ -11,6 +11,12 @@ public struct Fret {
     public let value: Int
     public let font: Font?
     public let color: Color?
+
+    public init(value: Int, font: Font? = nil, color: Color? = nil) {
+        self.value = value
+        self.font = font
+        self.color = color
+    }
 }
 
 extension Fret: Equatable { }

--- a/Sources/MusicXML/Complex Types/Glissando.swift
+++ b/Sources/MusicXML/Complex Types/Glissando.swift
@@ -16,6 +16,15 @@ public struct Glissando {
     public let lineType: LineType?
     public let dashedFormatting: DashedFormatting?
     public let printStyle: PrintStyle?
+
+    public init(value: String, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.type = type
+        self.number = number
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.printStyle = printStyle
+    }
 }
 
 extension Glissando: Equatable { }

--- a/Sources/MusicXML/Complex Types/Grace.swift
+++ b/Sources/MusicXML/Complex Types/Grace.swift
@@ -12,6 +12,13 @@ public struct Grace {
     public let stealTimeFollowing: Int?
     public let makeTime: Divisions?
     public let slash: Bool?
+
+    public init(stealTimePrevious: Int? = nil, stealTimeFollowing: Int? = nil, makeTime: Divisions? = nil, slash: Bool? = nil) {
+        self.stealTimePrevious = stealTimePrevious
+        self.stealTimeFollowing = stealTimeFollowing
+        self.makeTime = makeTime
+        self.slash = slash
+    }
 }
 
 extension Grace: Equatable { }

--- a/Sources/MusicXML/Complex Types/GroupBarline.swift
+++ b/Sources/MusicXML/Complex Types/GroupBarline.swift
@@ -9,6 +9,11 @@
 public struct GroupBarline {
     public var value: GroupBarlineValue
     public var color: Color?
+
+    public init(value: GroupBarlineValue, color: Color? = nil) {
+        self.value = value
+        self.color = color
+    }
 }
 
 extension GroupBarline: Equatable { }

--- a/Sources/MusicXML/Complex Types/GroupName.swift
+++ b/Sources/MusicXML/Complex Types/GroupName.swift
@@ -12,6 +12,12 @@ public struct GroupName {
     public let value: String
     public let printStyle: PrintStyle?
     public let justify: Justify?
+
+    public init(value: String, printStyle: PrintStyle? = nil, justify: Justify? = nil) {
+        self.value = value
+        self.printStyle = printStyle
+        self.justify = justify
+    }
 }
 
 extension GroupName: Equatable { }

--- a/Sources/MusicXML/Complex Types/GroupSymbol.swift
+++ b/Sources/MusicXML/Complex Types/GroupSymbol.swift
@@ -12,6 +12,12 @@ public struct GroupSymbol {
     public var value: GroupSymbolValue
     public var position: Position?
     public var color: Color?
+
+    public init(value: GroupSymbolValue, position: Position? = nil, color: Color? = nil) {
+        self.value = value
+        self.position = position
+        self.color = color
+    }
 }
 
 extension GroupSymbol: Equatable { }

--- a/Sources/MusicXML/Complex Types/Grouping.swift
+++ b/Sources/MusicXML/Complex Types/Grouping.swift
@@ -17,6 +17,13 @@ public struct Grouping {
     /// groupings.
     public let number: Int?
     public let memberOf: String?
+
+    public init(type: StartStopSingle, feature: [Feature], number: Int? = nil, memberOf: String? = nil) {
+        self.type = type
+        self.feature = feature
+        self.number = number
+        self.memberOf = memberOf
+    }
 }
 
 extension Grouping: Equatable { }

--- a/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
+++ b/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
@@ -16,6 +16,14 @@ public struct HammerOnPullOff {
     public let number: Int?
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(value: String, type: StartStop, number: Int? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.value = value
+        self.type = type
+        self.number = number
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension HammerOnPullOff: Equatable { }

--- a/Sources/MusicXML/Complex Types/Handbell.swift
+++ b/Sources/MusicXML/Complex Types/Handbell.swift
@@ -11,6 +11,12 @@ public struct Handbell {
     public let value: HandbellValue
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(value: HandbellValue, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.value = value
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Handbell: Equatable { }

--- a/Sources/MusicXML/Complex Types/Harmonic.swift
+++ b/Sources/MusicXML/Complex Types/Harmonic.swift
@@ -23,6 +23,14 @@ public struct Harmonic {
     public var printObject: Bool?
     public var printStyle: PrintStyle?
     public var placement: AboveBelow?
+
+    public init(naturalArtificial: NaturalArtificial? = nil, baseSoundingTouchingPitch: BaseSoundingTouchingPitch? = nil, printObject: Bool? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.naturalArtificial = naturalArtificial
+        self.baseSoundingTouchingPitch = baseSoundingTouchingPitch
+        self.printObject = printObject
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Harmonic {

--- a/Sources/MusicXML/Complex Types/Harmony.swift
+++ b/Sources/MusicXML/Complex Types/Harmony.swift
@@ -25,6 +25,19 @@ public struct Harmony {
     public let offset: Offset?
     public let editorial: Editorial?
     public let staff: Int?
+
+    public init(type: HarmonyType, printObject: Bool, printFrame: Bool? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil, chord: [HarmonyChord], frame: Frame? = nil, offset: Offset? = nil, editorial: Editorial? = nil, staff: Int? = nil) {
+        self.type = type
+        self.printObject = printObject
+        self.printFrame = printFrame
+        self.printStyle = printStyle
+        self.placement = placement
+        self.chord = chord
+        self.frame = frame
+        self.offset = offset
+        self.editorial = editorial
+        self.staff = staff
+    }
 }
 
 extension Harmony: Equatable { }

--- a/Sources/MusicXML/Complex Types/HarmonyChord.swift
+++ b/Sources/MusicXML/Complex Types/HarmonyChord.swift
@@ -40,6 +40,14 @@ public struct HarmonyChord {
     public let inversion: Inversion?
     public let bass: Bass?
     public let degree: [Degree] // NonEmpty
+
+    public init(rootOrFunction: RootOrFunction, kind: Kind, inversion: Inversion? = nil, bass: Bass? = nil, degree: [Degree]) {
+        self.rootOrFunction = rootOrFunction
+        self.kind = kind
+        self.inversion = inversion
+        self.bass = bass
+        self.degree = degree
+    }
 }
 
 extension HarmonyChord {

--- a/Sources/MusicXML/Complex Types/HarpPedals.swift
+++ b/Sources/MusicXML/Complex Types/HarpPedals.swift
@@ -12,6 +12,11 @@
 public struct HarpPedals {
     public let printStyleAlign: PrintStyleAlign
     public let pedalTuning: [PedalTuning]
+
+    public init(printStyleAlign: PrintStyleAlign, pedalTuning: [PedalTuning]) {
+        self.printStyleAlign = printStyleAlign
+        self.pedalTuning = pedalTuning
+    }
 }
 
 extension HarpPedals: Equatable { }

--- a/Sources/MusicXML/Complex Types/Header.swift
+++ b/Sources/MusicXML/Complex Types/Header.swift
@@ -21,6 +21,16 @@ public struct Header: Equatable {
     public var defaults: Defaults?
     public var credits: [Credit]?
     public var partList: PartList
+
+    public init(work: Work? = nil, movementNumber: String? = nil, movementTitle: String? = nil, identification: Identification? = nil, defaults: Defaults? = nil, credits: [Credit]? = nil, partList: PartList) {
+        self.work = work
+        self.movementNumber = movementNumber
+        self.movementTitle = movementTitle
+        self.identification = identification
+        self.defaults = defaults
+        self.credits = credits
+        self.partList = partList
+    }
 }
 
 extension Header: Codable {

--- a/Sources/MusicXML/Complex Types/HeelToe.swift
+++ b/Sources/MusicXML/Complex Types/HeelToe.swift
@@ -9,6 +9,11 @@
 public struct HeelToe {
     public let placement: AboveBelow?
     public let substitution: Bool?
+
+    public init(placement: AboveBelow? = nil, substitution: Bool? = nil) {
+        self.placement = placement
+        self.substitution = substitution
+    }
 }
 
 extension HeelToe: Equatable { }

--- a/Sources/MusicXML/Complex Types/Hole.swift
+++ b/Sources/MusicXML/Complex Types/Hole.swift
@@ -20,6 +20,14 @@ public struct Hole {
     public let holeShape: String?
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(holeType: String? = nil, holeClosed: HoleClosed, holeShape: String? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.holeType = holeType
+        self.holeClosed = holeClosed
+        self.holeShape = holeShape
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Hole: Equatable { }

--- a/Sources/MusicXML/Complex Types/HoleClosed.swift
+++ b/Sources/MusicXML/Complex Types/HoleClosed.swift
@@ -11,6 +11,11 @@ public struct HoleClosed {
     /// The optional location attribute indicates which portion of the hole is filled in when the
     /// element value is half.
     public let location: HoleClosedLocation?
+
+    public init(value: HoleClosedValue, location: HoleClosedLocation? = nil) {
+        self.value = value
+        self.location = location
+    }
 }
 
 extension HoleClosed: Equatable { }

--- a/Sources/MusicXML/Complex Types/HorizontalTurn.swift
+++ b/Sources/MusicXML/Complex Types/HorizontalTurn.swift
@@ -12,6 +12,13 @@ public struct HorizontalTurn {
     public var placement: AboveBelow?
     public var trillSound: TrillSound?
     public var slash: Bool?
+
+    public init(printStyle: PrintStyle? = nil, placement: AboveBelow? = nil, trillSound: TrillSound? = nil, slash: Bool? = nil) {
+        self.printStyle = printStyle
+        self.placement = placement
+        self.trillSound = trillSound
+        self.slash = slash
+    }
 }
 
 extension HorizontalTurn: Equatable { }

--- a/Sources/MusicXML/Complex Types/Identification.swift
+++ b/Sources/MusicXML/Complex Types/Identification.swift
@@ -37,6 +37,15 @@ public struct Identification {
     /// miscellaneous element. The miscellaneous type puts each separate part of metadata into its
     /// own miscellaneous-field type.
     public var miscellaneous: Miscellaneous?
+
+    public init(creators: [Creator]? = nil, rights: [Rights]? = nil, encoding: Encoding? = nil, source: String? = nil, relation: [String]? = nil, miscellaneous: Miscellaneous? = nil) {
+        self.creators = creators
+        self.rights = rights
+        self.encoding = encoding
+        self.source = source
+        self.relation = relation
+        self.miscellaneous = miscellaneous
+    }
 }
 
 extension Identification: Equatable { }

--- a/Sources/MusicXML/Complex Types/Image.swift
+++ b/Sources/MusicXML/Complex Types/Image.swift
@@ -12,6 +12,14 @@ public struct Image {
     public let position: Position?
     public let hAlign: LeftCenterRight?
     public let vAlign: VAlignImage?
+
+    public init(source: String, type: String, position: Position? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlignImage? = nil) {
+        self.source = source
+        self.type = type
+        self.position = position
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+    }
 }
 
 extension Image: Equatable { }

--- a/Sources/MusicXML/Complex Types/Instrument.swift
+++ b/Sources/MusicXML/Complex Types/Instrument.swift
@@ -10,6 +10,10 @@
 /// specified on a score-part, there should be an instrument element for each note in the part.
 public struct Instrument {
     public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
 }
 
 extension Instrument: Equatable { }

--- a/Sources/MusicXML/Complex Types/Interchangeable.swift
+++ b/Sources/MusicXML/Complex Types/Interchangeable.swift
@@ -10,6 +10,11 @@
 public struct Interchangeable {
     public let symbol: TimeSymbol
     public let separator: TimeSeparator
+
+    public init(symbol: TimeSymbol, separator: TimeSeparator) {
+        self.symbol = symbol
+        self.separator = separator
+    }
 }
 
 extension Interchangeable: Equatable { }

--- a/Sources/MusicXML/Complex Types/Inversion.swift
+++ b/Sources/MusicXML/Complex Types/Inversion.swift
@@ -10,6 +10,11 @@
 public struct Inversion {
     public let value: Int
     public let printStyle: PrintStyle
+
+    public init(value: Int, printStyle: PrintStyle) {
+        self.value = value
+        self.printStyle = printStyle
+    }
 }
 
 extension Inversion: Equatable { }

--- a/Sources/MusicXML/Complex Types/Key.swift
+++ b/Sources/MusicXML/Complex Types/Key.swift
@@ -15,15 +15,24 @@ public struct Key {
     // MARK: - Attributes
 
     /// The optional number attribute refers to staff numbers.
-    public var number: Int?
-    public var position: Position?
-    public var printStyle: PrintStyle?
-    public var printObject: Bool?
+    public let number: Int?
+    public let position: Position?
+    public let printStyle: PrintStyle?
+    public let printObject: Bool?
 
     // MARK: - Elements
 
-    public var kind: Kind
-    public var keyOctave: [KeyOctave]?
+    public let kind: Kind
+    public let keyOctave: [KeyOctave]?
+
+    public init(number: Int? = nil, position: Position? = nil, printStyle: PrintStyle? = nil, printObject: Bool? = nil, kind: Kind, keyOctave: [KeyOctave]? = nil) {
+        self.number = number
+        self.position = position
+        self.printStyle = printStyle
+        self.printObject = printObject
+        self.kind = kind
+        self.keyOctave = keyOctave
+    }
 }
 
 extension Key {
@@ -35,6 +44,11 @@ extension Key {
         self.number = staff
         self.kind = .traditional(Traditional(cancel: cancel, fifths: fifths, mode: mode))
         // TODO: Add remaining attributes and elements
+
+        self.position = nil
+        self.printStyle = nil
+        self.printObject = nil
+        self.keyOctave = nil
     }
 
     /// Creates a `NonTraditional` type `Key`.
@@ -43,6 +57,11 @@ extension Key {
             NonTraditional(step: step, alter: alter, accidental: accidental)
         )
         // TODO: Add remaining attributes and elements
+        self.number = nil
+        self.position = nil
+        self.printStyle = nil
+        self.printObject = nil
+        self.keyOctave = nil
     }
 }
 
@@ -52,6 +71,12 @@ extension Key {
         public var cancel: Cancel?
         public var fifths: Int
         public var mode: Mode?
+
+        public init(cancel: Cancel? = nil, fifths: Int, mode: Mode? = nil) {
+            self.cancel = cancel
+            self.fifths = fifths
+            self.mode = mode
+        }
     }
 
     /// Non-traditional key signatures can be represented using the Humdrum/Scot concept of a list
@@ -61,6 +86,12 @@ extension Key {
         public var step: Step
         public var alter: Double
         public var accidental: AccidentalValue
+
+        public init(step: Step, alter: Double, accidental: AccidentalValue) {
+            self.step = step
+            self.alter = alter
+            self.accidental = accidental
+        }
     }
 
     public enum Kind {

--- a/Sources/MusicXML/Complex Types/KeyOctave.swift
+++ b/Sources/MusicXML/Complex Types/KeyOctave.swift
@@ -10,6 +10,11 @@
 public struct KeyOctave {
     public let number: Int
     public let cancel: Bool
+
+    public init(number: Int, cancel: Bool) {
+        self.number = number
+        self.cancel = cancel
+    }
 }
 
 extension KeyOctave: Equatable { }

--- a/Sources/MusicXML/Complex Types/Kind.swift
+++ b/Sources/MusicXML/Complex Types/Kind.swift
@@ -19,6 +19,18 @@ public struct Kind {
     public let printStyle: PrintStyle?
     public let horizontalAlignment: LeftCenterRight?
     public let verticalAlignment: VAlign?
+
+    public init(value: KindValue, useSymbols: Bool? = nil, text: String? = nil, stackDegrees: Bool? = nil, parenthesesDegrees: Bool? = nil, bracketDegrees: Bool? = nil, printStyle: PrintStyle? = nil, horizontalAlignment: LeftCenterRight? = nil, verticalAlignment: VAlign? = nil) {
+        self.value = value
+        self.useSymbols = useSymbols
+        self.text = text
+        self.stackDegrees = stackDegrees
+        self.parenthesesDegrees = parenthesesDegrees
+        self.bracketDegrees = bracketDegrees
+        self.printStyle = printStyle
+        self.horizontalAlignment = horizontalAlignment
+        self.verticalAlignment = verticalAlignment
+    }
 }
 
 extension Kind: Equatable { }

--- a/Sources/MusicXML/Complex Types/Level.swift
+++ b/Sources/MusicXML/Complex Types/Level.swift
@@ -9,6 +9,11 @@
 public struct Level {
     public let reference: Bool
     public let levelDisplay: LevelDisplay
+
+    public init(reference: Bool, levelDisplay: LevelDisplay) {
+        self.reference = reference
+        self.levelDisplay = levelDisplay
+    }
 }
 
 extension Level: Equatable { }

--- a/Sources/MusicXML/Complex Types/LevelDisplay.swift
+++ b/Sources/MusicXML/Complex Types/LevelDisplay.swift
@@ -13,6 +13,12 @@ public struct LevelDisplay {
     public let parentheses: Bool
     public let bracket: Bool
     public let size: SymbolSize
+
+    public init(parentheses: Bool, bracket: Bool, size: SymbolSize) {
+        self.parentheses = parentheses
+        self.bracket = bracket
+        self.size = size
+    }
 }
 
 extension LevelDisplay: Equatable { }

--- a/Sources/MusicXML/Complex Types/LineWidth.swift
+++ b/Sources/MusicXML/Complex Types/LineWidth.swift
@@ -10,6 +10,11 @@
 public struct LineWidth {
     public let value: Tenths
     public let type: LineWidthType
+
+    public init(value: Tenths, type: LineWidthType) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension LineWidth: Equatable { }

--- a/Sources/MusicXML/Complex Types/LinearArrow.swift
+++ b/Sources/MusicXML/Complex Types/LinearArrow.swift
@@ -8,6 +8,11 @@
 public struct LinearArrow {
     let direction: ArrowDirection
     let style: ArrowStyle?
+
+    public init(direction: ArrowDirection, style: ArrowStyle? = nil) {
+        self.direction = direction
+        self.style = style
+    }
 }
 
 extension LinearArrow: Equatable { }

--- a/Sources/MusicXML/Complex Types/Link.swift
+++ b/Sources/MusicXML/Complex Types/Link.swift
@@ -51,6 +51,12 @@ public struct Link {
     //    This is equivalent to an XPath test of [.//beam[2]] done
     //    in the context of the sibling element.
     public let position: String?
+
+    public init(name: String? = nil, element: String? = nil, position: String? = nil) {
+        self.name = name
+        self.element = element
+        self.position = position
+    }
 }
 
 extension Link: Equatable { }

--- a/Sources/MusicXML/Complex Types/Lyric.swift
+++ b/Sources/MusicXML/Complex Types/Lyric.swift
@@ -36,6 +36,18 @@ public struct Lyric {
     public let endParagraph: Empty?
 
     public let kind: Kind
+
+    public init(number: String? = nil, name: String? = nil, justify: LeftCenterRight? = nil, position: Position? = nil, placement: AboveBelow? = nil, printObject: Bool? = nil, endLine: Empty? = nil, endParagraph: Empty? = nil, kind: Kind) {
+        self.number = number
+        self.name = name
+        self.justify = justify
+        self.position = position
+        self.placement = placement
+        self.printObject = printObject
+        self.endLine = endLine
+        self.endParagraph = endParagraph
+        self.kind = kind
+    }
 }
 
 extension Lyric {
@@ -44,6 +56,11 @@ extension Lyric {
     public struct Verbal {
         public let text: TextElementData
         public let syllabic: Syllabic?
+
+        public init(text: TextElementData, syllabic: Syllabic? = nil) {
+            self.text = text
+            self.syllabic = syllabic
+        }
     }
 
     // > Humming and laughing representations are taken from

--- a/Sources/MusicXML/Complex Types/LyricFont.swift
+++ b/Sources/MusicXML/Complex Types/LyricFont.swift
@@ -10,6 +10,12 @@ public struct LyricFont {
     public let number: Int?
     public let name: String?
     public let font: Font
+
+    public init(number: Int? = nil, name: String? = nil, font: Font) {
+        self.number = number
+        self.name = name
+        self.font = font
+    }
 }
 
 extension LyricFont: Equatable { }

--- a/Sources/MusicXML/Complex Types/LyricLanguage.swift
+++ b/Sources/MusicXML/Complex Types/LyricLanguage.swift
@@ -10,4 +10,10 @@ public struct LyricLanguage: Codable, Equatable {
     public let number: Int?
     public let name: String?
     public let language: String?
+
+    public init(number: Int? = nil, name: String? = nil, language: String? = nil) {
+        self.number = number
+        self.name = name
+        self.language = language
+    }
 }

--- a/Sources/MusicXML/Complex Types/MIDIDevice.swift
+++ b/Sources/MusicXML/Complex Types/MIDIDevice.swift
@@ -18,6 +18,12 @@ public struct MIDIDevice {
     /// The optional id attribute refers to the score-instrument assigned to this device. If
     /// missing, the device assignment affects all score-instrument elements in the score-part.
     public var id: String?
+
+    public init(value: String? = nil, port: Int? = nil, id: String? = nil) {
+        self.value = value
+        self.port = port
+        self.id = id
+    }
 }
 
 extension MIDIDevice: Equatable { }

--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -38,6 +38,18 @@ public struct MIDIInstrument {
     /// listener. Both are expressed in degrees ranging from -180 to 180. For elevation, 0 is level
     /// with the listener, 90 is directly above, and -90 is directly below.
     public var elevation: Int?
+
+    public init(id: String, midiChannel: Int? = nil, midiName: String? = nil, midiBank: Int? = nil, midiProgram: Int? = nil, midiUnpitched: Int? = nil, volume: Double? = nil, pan: Int? = nil, elevation: Int? = nil) {
+        self.id = id
+        self.midiChannel = midiChannel
+        self.midiName = midiName
+        self.midiBank = midiBank
+        self.midiProgram = midiProgram
+        self.midiUnpitched = midiUnpitched
+        self.volume = volume
+        self.pan = pan
+        self.elevation = elevation
+    }
 }
 
 extension MIDIInstrument: Equatable { }

--- a/Sources/MusicXML/Complex Types/MeasureLayout.swift
+++ b/Sources/MusicXML/Complex Types/MeasureLayout.swift
@@ -12,6 +12,10 @@ public struct MeasureLayout {
     /// system, as in systems with codas. To specify the measure width, use the width attribute of
     /// the measure element.
     public let measureDistance: Tenths?
+
+    public init(measureDistance: Tenths? = nil) {
+        self.measureDistance = measureDistance
+    }
 }
 
 extension MeasureLayout: Equatable { }

--- a/Sources/MusicXML/Complex Types/MeasureNumbering.swift
+++ b/Sources/MusicXML/Complex Types/MeasureNumbering.swift
@@ -10,6 +10,11 @@
 public struct MeasureNumbering {
     public let value: MeasureNumberingValue
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(value: MeasureNumberingValue, printStyleAlign: PrintStyleAlign? = nil) {
+        self.value = value
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension MeasureNumbering: Equatable { }

--- a/Sources/MusicXML/Complex Types/MeasureRepeat.swift
+++ b/Sources/MusicXML/Complex Types/MeasureRepeat.swift
@@ -14,6 +14,11 @@
 public struct MeasureRepeat {
     public let type: StartStop
     public let slashes: Int
+
+    public init(type: StartStop, slashes: Int) {
+        self.type = type
+        self.slashes = slashes
+    }
 }
 
 extension MeasureRepeat: Equatable { }

--- a/Sources/MusicXML/Complex Types/MeasureStyle.swift
+++ b/Sources/MusicXML/Complex Types/MeasureStyle.swift
@@ -24,6 +24,13 @@ public struct MeasureStyle {
     // MARK: - Elements
 
     public var kind: Kind
+
+    public init(number: Int? = nil, font: Font? = nil, color: Color? = nil, kind: Kind) {
+        self.number = number
+        self.font = font
+        self.color = color
+        self.kind = kind
+    }
 }
 
 extension MeasureStyle {

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -13,12 +13,19 @@ import XMLCoder
 /// relationships, such as swing tempo marks where two eighths are equated to a quarter note /
 /// eighth note triplet.
 public struct Metronome {
-    public var printStyleAlign: PrintStyleAlign?
-    public var justify: Justify?
+    public let printStyleAlign: PrintStyleAlign?
+    public let justify: Justify?
     /// The parentheses attribute indicates whether or not to put the metronome mark in parentheses;
     /// its value is no if not specified.
-    public var parentheses: Bool?
-    public var kind: Kind
+    public let parentheses: Bool?
+    public let kind: Kind
+
+    public init(printStyleAlign: PrintStyleAlign? = nil, justify: Justify? = nil, parentheses: Bool? = nil, kind: Kind) {
+        self.printStyleAlign = printStyleAlign
+        self.justify = justify
+        self.parentheses = parentheses
+        self.kind = kind
+    }
 }
 
 extension Metronome {
@@ -38,6 +45,12 @@ extension Metronome {
         /// note.
         public let beatUnitDot: [Empty]
         public let relation: Relation
+
+        public init(beatUnit: NoteTypeValue, beatUnitDot: [Empty], relation: Relation) {
+            self.beatUnit = beatUnit
+            self.beatUnitDot = beatUnitDot
+            self.relation = relation
+        }
     }
 
     // TODO: Consider naming
@@ -45,6 +58,12 @@ extension Metronome {
         public let metronomeNote: [MetronomeNote] // NonEmpty
         public let metronomeRelation: String?
         public let otherMetronomeNote: [MetronomeNote] // NonEmpty
+
+        public init(metronomeNote: [MetronomeNote], metronomeRelation: String? = nil, otherMetronomeNote: [MetronomeNote]) {
+            self.metronomeNote = metronomeNote
+            self.metronomeRelation = metronomeRelation
+            self.otherMetronomeNote = otherMetronomeNote
+        }
     }
 
     public enum Kind {

--- a/Sources/MusicXML/Complex Types/MetronomeBeam.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeBeam.swift
@@ -10,6 +10,11 @@
 public struct MetronomeBeam {
     public let value: BeamValue
     public let number: BeamLevel?
+
+    public init(value: BeamValue, number: BeamLevel? = nil) {
+        self.value = value
+        self.number = number
+    }
 }
 
 extension MetronomeBeam: Equatable { }

--- a/Sources/MusicXML/Complex Types/MetronomeNote.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeNote.swift
@@ -11,6 +11,13 @@ public struct MetronomeNote {
     public let metronomeDot: [Empty]
     public let metronomeBeam: [MetronomeBeam]
     public let metronomeTuplet: MetronomeTuplet?
+
+    public init(metronomeType: NoteTypeValue, metronomeDot: [Empty], metronomeBeam: [MetronomeBeam], metronomeTuplet: MetronomeTuplet? = nil) {
+        self.metronomeType = metronomeType
+        self.metronomeDot = metronomeDot
+        self.metronomeBeam = metronomeBeam
+        self.metronomeTuplet = metronomeTuplet
+    }
 }
 
 extension MetronomeNote: Equatable { }

--- a/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
@@ -12,6 +12,13 @@ public struct MetronomeTuplet {
     public let type: StartStop
     public let bracket: Bool?
     public let showNumber: ShowTuplet?
+
+    public init(value: TimeModification, type: StartStop, bracket: Bool? = nil, showNumber: ShowTuplet? = nil) {
+        self.value = value
+        self.type = type
+        self.bracket = bracket
+        self.showNumber = showNumber
+    }
 }
 
 extension MetronomeTuplet: Equatable { }

--- a/Sources/MusicXML/Complex Types/Miscellaneous.swift
+++ b/Sources/MusicXML/Complex Types/Miscellaneous.swift
@@ -10,6 +10,10 @@
 /// miscellaneous-field type.
 public struct Miscellaneous {
     public let fields: [MiscellaneousField]
+
+    public init(fields: [MiscellaneousField]) {
+        self.fields = fields
+    }
 }
 
 extension Miscellaneous: Equatable { }

--- a/Sources/MusicXML/Complex Types/MiscellaneousField.swift
+++ b/Sources/MusicXML/Complex Types/MiscellaneousField.swift
@@ -15,6 +15,11 @@ public struct MiscellaneousField {
     public let name: String
     // MARK: - Value
     public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
 }
 
 extension MiscellaneousField: Equatable { }

--- a/Sources/MusicXML/Complex Types/Mordent.swift
+++ b/Sources/MusicXML/Complex Types/Mordent.swift
@@ -12,6 +12,13 @@ public struct Mordent {
     public let long: Bool?
     public let approach: AboveBelow?
     public let departure: AboveBelow?
+
+    public init(emptyTrillSound: EmptyTrillSound? = nil, long: Bool? = nil, approach: AboveBelow? = nil, departure: AboveBelow? = nil) {
+        self.emptyTrillSound = emptyTrillSound
+        self.long = long
+        self.approach = approach
+        self.departure = departure
+    }
 }
 
 extension Mordent: Equatable { }

--- a/Sources/MusicXML/Complex Types/MultipleRest.swift
+++ b/Sources/MusicXML/Complex Types/MultipleRest.swift
@@ -17,6 +17,11 @@ public struct MultipleRest {
     // MARK: - Value
 
     public var value: Int
+
+    public init(useSymbols: Bool? = nil, value: Int) {
+        self.useSymbols = useSymbols
+        self.value = value
+    }
 }
 
 extension MultipleRest: Equatable { }

--- a/Sources/MusicXML/Complex Types/MusicXML.String.swift
+++ b/Sources/MusicXML/Complex Types/MusicXML.String.swift
@@ -12,6 +12,12 @@ extension MusicXML {
         public let value: StringNumber
         public let printStyle: PrintStyle?
         public let placement: AboveBelow?
+
+        public init(value: StringNumber, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+            self.value = value
+            self.printStyle = printStyle
+            self.placement = placement
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/NameDisplay.swift
+++ b/Sources/MusicXML/Complex Types/NameDisplay.swift
@@ -12,6 +12,11 @@
 public struct NameDisplay {
     public let printObject: Bool
     public let text: Text
+
+    public init(printObject: Bool, text: Text) {
+        self.printObject = printObject
+        self.text = text
+    }
 }
 
 extension NameDisplay {

--- a/Sources/MusicXML/Complex Types/NonArpeggiate.swift
+++ b/Sources/MusicXML/Complex Types/NonArpeggiate.swift
@@ -17,6 +17,14 @@ public struct NonArpeggiate {
     public var position: Position?
     public var placement: AboveBelow?
     public var color: Color?
+
+    public init(type: TopBottom, number: Int? = nil, position: Position? = nil, placement: AboveBelow? = nil, color: Color? = nil) {
+        self.type = type
+        self.number = number
+        self.position = position
+        self.placement = placement
+        self.color = color
+    }
 }
 
 extension NonArpeggiate: Equatable { }

--- a/Sources/MusicXML/Complex Types/Notations.swift
+++ b/Sources/MusicXML/Complex Types/Notations.swift
@@ -22,6 +22,13 @@ public struct Notations {
     public var footnote: FormattedText?
     public var level: Level?
     public var values: [Notation]
+
+    public init(printObject: Bool? = nil, footnote: FormattedText? = nil, level: Level? = nil, values: [Notation]) {
+        self.printObject = printObject
+        self.footnote = footnote
+        self.level = level
+        self.values = values
+    }
 }
 
 extension Notations {

--- a/Sources/MusicXML/Complex Types/Note.swift
+++ b/Sources/MusicXML/Complex Types/Note.swift
@@ -13,67 +13,159 @@
 /// easier, as some programs handle one type of information much more readily than the other.
 public struct Note {
 
-    public var kind: Kind
+    public let kind: Kind
 
     // MARK: - Attributes
 
-    public var position: Position = Position()
-    public var fontFamily: CommaSeparatedText?
-    public var fontStyle: FontStyle?
-    public var fontSize: FontSize?
-    public var fontWeight: FontWeight?
-    public var color: Color?
-    public var printStyle: PrintStyle?
-    public var printObject: Bool?
-    public var printDot: Bool?
-    public var printSpacing: Bool?
-    public var printLyric: Bool?
-    public var dynamics: Double?
-    public var endDynamics: Double?
-    public var attack: Divisions?
-    public var release: Divisions?
-    public var timeOnly: TimeOnly?
-    public var pizzicato: Bool?
+    public let position: Position
+    public let fontFamily: CommaSeparatedText?
+    public let fontStyle: FontStyle?
+    public let fontSize: FontSize?
+    public let fontWeight: FontWeight?
+    public let color: Color?
+    public let printStyle: PrintStyle?
+    public let printObject: Bool?
+    public let printDot: Bool?
+    public let printSpacing: Bool?
+    public let printLyric: Bool?
+    public let dynamics: Double?
+    public let endDynamics: Double?
+    public let attack: Divisions?
+    public let release: Divisions?
+    public let timeOnly: TimeOnly?
+    public let pizzicato: Bool?
 
     // MARK: - Elements
 
-    public var instrument: Instrument?
-    public var footnote: FormattedText?
-    public var level: Level?
-    public var voice: String?
-    public var type: NoteType?
+    public let instrument: Instrument?
+    public let footnote: FormattedText?
+    public let level: Level?
+    public let voice: String?
+    public let type: NoteType?
     #warning("Reinstate Note.dots when we can decode potentially-empty elements properly")
-    // public var dots: [EmptyPlacement]?
-    public var accidental: Accidental?
-    public var timeModification: TimeModification?
-    public var stem: Stem?
-    public var notehead: Notehead?
-    public var noteheadText: NoteheadText?
-    public var staff: Int?
-    public var beams: [Beam]? // Up to 8
-    public var notations: Notations?
-    public var lyrics: [Lyric]?
-    public var play: Play?
+    // public let dots: [EmptyPlacement]?
+    public let accidental: Accidental?
+    public let timeModification: TimeModification?
+    public let stem: Stem?
+    public let notehead: Notehead?
+    public let noteheadText: NoteheadText?
+    public let staff: Int?
+    public let beams: [Beam]? // Up to 8
+    public let notations: Notations?
+    public let lyrics: [Lyric]?
+    public let play: Play?
+
+    public init(
+        kind: Kind,
+        position: Position = Position(),
+        fontFamily: CommaSeparatedText? = nil,
+        fontStyle: FontStyle? = nil,
+        fontSize: FontSize? = nil,
+        fontWeight: FontWeight? = nil,
+        color: Color? = nil,
+        printStyle: PrintStyle? = nil,
+        printObject: Bool? = nil,
+        printDot: Bool? = nil,
+        printSpacing: Bool? = nil,
+        printLyric: Bool? = nil,
+        dynamics: Double? = nil,
+        endDynamics: Double? = nil,
+        attack: Divisions? = nil,
+        release: Divisions? = nil,
+        timeOnly: TimeOnly? = nil,
+        pizzicato: Bool? = nil,
+        instrument: Instrument? = nil,
+        footnote: FormattedText? = nil,
+        level: Level? = nil,
+        voice: String? = nil,
+        type: NoteType? = nil,
+        // dots: [EmptyPlacement]? = nil,
+        accidental: Accidental? = nil,
+        timeModification: TimeModification? = nil,
+        stem: Stem? = nil,
+        notehead: Notehead? = nil,
+        noteheadText: NoteheadText? = nil,
+        staff: Int? = nil,
+        beams: [Beam]? = nil,
+        notations: Notations? = nil,
+        lyrics: [Lyric]? = nil,
+        play: Play? = nil) {
+
+        self.kind = kind
+        self.position = position
+        self.fontFamily = fontFamily
+        self.fontStyle = fontStyle
+        self.fontSize = fontSize
+        self.fontWeight = fontWeight
+        self.color = color
+        self.printStyle = printStyle
+        self.printObject = printObject
+        self.printDot = printDot
+        self.printSpacing = printSpacing
+        self.printLyric = printLyric
+        self.dynamics = dynamics
+        self.endDynamics = endDynamics
+        self.attack = attack
+        self.release = release
+        self.timeOnly = timeOnly
+        self.pizzicato = pizzicato
+        self.instrument = instrument
+        self.footnote = footnote
+        self.level = level
+        self.voice = voice
+        self.type = type
+        #warning("Reinstate Note.dots when we can decode potentially-empty elements properly")
+        // self.dots = dots
+        self.accidental = accidental
+        self.timeModification = timeModification
+        self.stem = stem
+        self.notehead = notehead
+        self.noteheadText = noteheadText
+        self.staff = staff
+        self.beams = beams
+        self.notations = notations
+        self.lyrics = lyrics
+        self.play = play
+    }
 }
 
 extension Note {
     public struct Normal: Equatable {
-        public var chord = false
-        public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
-        public var duration: Int
-        public var ties: Ties?
+        public let chord: Bool
+        public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
+        public let duration: Int
+        public let ties: Ties?
+
+        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, duration: Int, ties: Ties? = nil) {
+            self.chord = chord
+            self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
+            self.duration = duration
+            self.ties = ties
+        }
     }
 
     public struct Cue: Equatable {
-        public var chord = false
-        public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
-        public var duration: Int
+        public let chord: Bool
+        public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
+        public let duration: Int
+
+        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, duration: Int) {
+            self.chord = chord
+            self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
+            self.duration = duration
+        }
     }
 
     public struct Grace: Equatable {
-        public var chord = false
-        public var pitchUnpitchedOrRest: PitchUnpitchedOrRest
-        public var ties: Ties?
+        public let chord: Bool
+        public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
+        public let ties: Ties?
+
+        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, ties: Ties? = nil) {
+            self.chord = chord
+            self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
+            self.ties = ties
+        }
     }
 
     public enum Kind: Equatable {

--- a/Sources/MusicXML/Complex Types/NoteSize.swift
+++ b/Sources/MusicXML/Complex Types/NoteSize.swift
@@ -14,6 +14,11 @@
 public struct NoteSize {
     public let value: NonNegativeDecimal
     public let type: NoteSizeType
+
+    public init(value: NonNegativeDecimal, type: NoteSizeType) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension NoteSize: Equatable { }

--- a/Sources/MusicXML/Complex Types/NoteType.swift
+++ b/Sources/MusicXML/Complex Types/NoteType.swift
@@ -7,8 +7,13 @@
 
 /// The note-type type indicates the graphic note type. Values range from 256th to long.
 public struct NoteType {
-    public var value: NoteTypeValue
-    public var size: SymbolSize?
+    public let value: NoteTypeValue
+    public let size: SymbolSize?
+
+    public init(value: NoteTypeValue, size: SymbolSize? = nil) {
+        self.value = value
+        self.size = size
+    }
 }
 
 extension NoteType: Equatable { }

--- a/Sources/MusicXML/Complex Types/Notehead.swift
+++ b/Sources/MusicXML/Complex Types/Notehead.swift
@@ -14,6 +14,14 @@ public struct Notehead {
     public let parentheses: Bool
     public let font: Font
     public let color: Color
+
+    public init(value: NoteheadValue, filled: Bool, parentheses: Bool, font: Font, color: Color) {
+        self.value = value
+        self.filled = filled
+        self.parentheses = parentheses
+        self.font = font
+        self.color = color
+    }
 }
 
 extension Notehead: Equatable { }

--- a/Sources/MusicXML/Complex Types/NoteheadText.swift
+++ b/Sources/MusicXML/Complex Types/NoteheadText.swift
@@ -13,6 +13,10 @@ public struct NoteheadText {
         case accidentalText(AccidentalText)
     }
     public let values: [Kind] // NonEmpty
+
+    public init(values: [Kind]) {
+        self.values = values
+    }
 }
 
 extension NoteheadText.Kind: Equatable { }

--- a/Sources/MusicXML/Complex Types/OctaveShift.swift
+++ b/Sources/MusicXML/Complex Types/OctaveShift.swift
@@ -15,6 +15,14 @@ public struct OctaveShift {
     public let size: Int?
     public let dashedFormatting: DashedFormatting?
     public let printStyle: PrintStyle?
+
+    public init(type: StartStopContinue, number: Int? = nil, size: Int? = nil, dashedFormatting: DashedFormatting? = nil, printStyle: PrintStyle? = nil) {
+        self.type = type
+        self.number = number
+        self.size = size
+        self.dashedFormatting = dashedFormatting
+        self.printStyle = printStyle
+    }
 }
 
 extension OctaveShift: Equatable { }

--- a/Sources/MusicXML/Complex Types/Offset.swift
+++ b/Sources/MusicXML/Complex Types/Offset.swift
@@ -12,6 +12,11 @@
 public struct Offset {
     public let value: Divisions
     public let sound: Bool
+
+    public init(value: Divisions, sound: Bool) {
+        self.value = value
+        self.sound = sound
+    }
 }
 
 extension Offset: Equatable { }

--- a/Sources/MusicXML/Complex Types/Opus.swift
+++ b/Sources/MusicXML/Complex Types/Opus.swift
@@ -10,6 +10,9 @@
 #warning("TODO: Flesh out Opus")
 public struct Opus {
 
+
+    public init() {
+    }
 }
 
 extension Opus: Equatable { }

--- a/Sources/MusicXML/Complex Types/Ornaments.swift
+++ b/Sources/MusicXML/Complex Types/Ornaments.swift
@@ -14,6 +14,11 @@ public struct Ornaments {
 
     public var values: [Ornament]
     public var accidentalMarks: [AccidentalMark]?
+
+    public init(values: [Ornament], accidentalMarks: [AccidentalMark]? = nil) {
+        self.values = values
+        self.accidentalMarks = accidentalMarks
+    }
 }
 
 extension Ornaments: Equatable { }

--- a/Sources/MusicXML/Complex Types/OtherAppearance.swift
+++ b/Sources/MusicXML/Complex Types/OtherAppearance.swift
@@ -11,6 +11,11 @@
 public struct OtherAppearance {
     public let value: String
     public let type: String
+
+    public init(value: String, type: String) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension OtherAppearance: Equatable { }

--- a/Sources/MusicXML/Complex Types/OtherDirection.swift
+++ b/Sources/MusicXML/Complex Types/OtherDirection.swift
@@ -12,6 +12,12 @@ public struct OtherDirection {
     public let value: String
     public let printObject: Bool?
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(value: String, printObject: Bool? = nil, printStyleAlign: PrintStyleAlign? = nil) {
+        self.value = value
+        self.printObject = printObject
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension OtherDirection: Equatable { }

--- a/Sources/MusicXML/Complex Types/OtherDynamics.swift
+++ b/Sources/MusicXML/Complex Types/OtherDynamics.swift
@@ -7,6 +7,10 @@
 
 public struct OtherDynamics {
     public let smufl: SMuFL
+
+    public init(smufl: SMuFL) {
+        self.smufl = smufl
+    }
 }
 
 extension OtherDynamics: Equatable { }

--- a/Sources/MusicXML/Complex Types/OtherNotation.swift
+++ b/Sources/MusicXML/Complex Types/OtherNotation.swift
@@ -16,6 +16,15 @@ public struct OtherNotation {
     public let printObject: Bool?
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(value: String, type: StartStopSingle, number: Int? = nil, printObject: Bool? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.value = value
+        self.type = type
+        self.number = number
+        self.printObject = printObject
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension OtherNotation: Equatable { }

--- a/Sources/MusicXML/Complex Types/OtherPlay.swift
+++ b/Sources/MusicXML/Complex Types/OtherPlay.swift
@@ -10,6 +10,11 @@
 public struct OtherPlay {
     public let value: String
     public let type: String
+
+    public init(value: String, type: String) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension OtherPlay: Equatable { }

--- a/Sources/MusicXML/Complex Types/PageLayout.swift
+++ b/Sources/MusicXML/Complex Types/PageLayout.swift
@@ -12,6 +12,11 @@
 public struct PageLayout {
     public let size: Size?
     public let margins: [Margins]
+
+    public init(size: Size? = nil, margins: [Margins]) {
+        self.size = size
+        self.margins = margins
+    }
 }
 
 extension PageLayout {
@@ -19,12 +24,22 @@ extension PageLayout {
     public struct Size: Codable, Equatable {
         let height: Tenths
         let width: Tenths
+
+        public init(height: Tenths, width: Tenths) {
+            self.height = height
+            self.width = width
+        }
     }
 
     #warning("FIXME: Refactor Margins a little better to encode logic")
     public struct Margins: Codable, Equatable {
         let even: PageMargins
         let odd: PageMargins?
+
+        public init(even: PageMargins, odd: PageMargins? = nil) {
+            self.even = even
+            self.odd = odd
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/PageMargins.swift
+++ b/Sources/MusicXML/Complex Types/PageMargins.swift
@@ -13,6 +13,14 @@ public struct PageMargins {
     public let right: Tenths
     public let top: Tenths
     public let bottom: Tenths
+
+    public init(kind: Kind, left: Tenths, right: Tenths, top: Tenths, bottom: Tenths) {
+        self.kind = kind
+        self.left = left
+        self.right = right
+        self.top = top
+        self.bottom = bottom
+    }
 }
 
 extension PageMargins {

--- a/Sources/MusicXML/Complex Types/PartGroup.swift
+++ b/Sources/MusicXML/Complex Types/PartGroup.swift
@@ -26,6 +26,19 @@ public struct PartGroup {
     public var barline: GroupBarline?
     public var time: Bool?
     public var editorial: Editorial?
+
+    public init(type: StartStop, number: Int? = nil, name: GroupName? = nil, nameDisplay: NameDisplay? = nil, abbreviation: GroupName? = nil, abbreviationDisplay: NameDisplay? = nil, symbol: GroupSymbol? = nil, barline: GroupBarline? = nil, time: Bool? = nil, editorial: Editorial? = nil) {
+        self.type = type
+        self.number = number
+        self.name = name
+        self.nameDisplay = nameDisplay
+        self.abbreviation = abbreviation
+        self.abbreviationDisplay = abbreviationDisplay
+        self.symbol = symbol
+        self.barline = barline
+        self.time = time
+        self.editorial = editorial
+    }
 }
 
 extension PartGroup: Equatable { }

--- a/Sources/MusicXML/Complex Types/PartList.swift
+++ b/Sources/MusicXML/Complex Types/PartList.swift
@@ -18,6 +18,10 @@ public struct PartList {
     public init(_ parts: [Item]) {
         self.parts = parts
     }
+
+    public init(parts: [Item]) {
+        self.parts = parts
+    }
 }
 
 extension PartList {

--- a/Sources/MusicXML/Complex Types/PartName.swift
+++ b/Sources/MusicXML/Complex Types/PartName.swift
@@ -13,6 +13,13 @@ public struct PartName {
     public var printStyle: PrintStyle?
     public var printObject: Bool?
     public var justify: Justify?
+
+    public init(value: String, printStyle: PrintStyle? = nil, printObject: Bool? = nil, justify: Justify? = nil) {
+        self.value = value
+        self.printStyle = printStyle
+        self.printObject = printObject
+        self.justify = justify
+    }
 }
 
 extension PartName: Equatable { }

--- a/Sources/MusicXML/Complex Types/PartSymbol.swift
+++ b/Sources/MusicXML/Complex Types/PartSymbol.swift
@@ -17,6 +17,15 @@ public struct PartSymbol {
     let bottomStaff: Int
     let position: Position
     let color: Color
+
+    public init(value: GroupSymbolValue, kind: Kind, topStaff: Int, bottomStaff: Int, position: Position, color: Color) {
+        self.value = value
+        self.kind = kind
+        self.topStaff = topStaff
+        self.bottomStaff = bottomStaff
+        self.position = position
+        self.color = color
+    }
 }
 
 extension PartSymbol: Equatable { }

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.Measure.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.Measure.swift
@@ -51,13 +51,23 @@ extension Partwise {
     //     %optional-unique-id;
     // >
     public struct Measure: Equatable {
-        public var number: Int
-        public var text: String?
-        public var implicit: Bool?
-        public var nonControlling: Bool?
-        public var width: Tenths?
-        public var optionalUniqueID: Int?
-        public var musicData: [MusicData]
+        public let number: Int
+        public let text: String?
+        public let implicit: Bool?
+        public let nonControlling: Bool?
+        public let width: Tenths?
+        public let optionalUniqueID: Int?
+        public let musicData: [MusicData]
+
+        public init(number: Int, text: String? = nil, implicit: Bool? = nil, nonControlling: Bool? = nil, width: Tenths? = nil, optionalUniqueID: Int? = nil, musicData: [MusicData] = []) {
+            self.number = number
+            self.text = text
+            self.implicit = implicit
+            self.nonControlling = nonControlling
+            self.width = width
+            self.optionalUniqueID = optionalUniqueID
+            self.musicData = musicData
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
@@ -17,6 +17,16 @@ public struct Partwise {
     public var defaults: Defaults?
     public var credits: [Credit]?
     public var parts: [Part]
+
+    public init(work: Work? = nil, movementNumber: String? = nil, movementTitle: String? = nil, identification: Identification? = nil, defaults: Defaults? = nil, credits: [Credit]? = nil, parts: [Part]) {
+        self.work = work
+        self.movementNumber = movementNumber
+        self.movementTitle = movementTitle
+        self.identification = identification
+        self.defaults = defaults
+        self.credits = credits
+        self.parts = parts
+    }
 }
 
 extension Partwise: Equatable { }

--- a/Sources/MusicXML/Complex Types/Pedal.swift
+++ b/Sources/MusicXML/Complex Types/Pedal.swift
@@ -14,6 +14,13 @@ public struct Pedal {
     public let line: Bool?
     public let sign: Bool?
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(type: StartStopContinue, line: Bool? = nil, sign: Bool? = nil, printStyleAlign: PrintStyleAlign? = nil) {
+        self.type = type
+        self.line = line
+        self.sign = sign
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension Pedal: Equatable { }

--- a/Sources/MusicXML/Complex Types/PedalTuning.swift
+++ b/Sources/MusicXML/Complex Types/PedalTuning.swift
@@ -9,6 +9,11 @@
 public struct PedalTuning {
     public let pedalStep: Step
     public let pedalAlter: Int
+
+    public init(pedalStep: Step, pedalAlter: Int) {
+        self.pedalStep = pedalStep
+        self.pedalAlter = pedalAlter
+    }
 }
 
 extension PedalTuning: Equatable { }

--- a/Sources/MusicXML/Complex Types/PerMinute.swift
+++ b/Sources/MusicXML/Complex Types/PerMinute.swift
@@ -12,6 +12,11 @@
 public struct PerMinute {
     public let value: String
     public let font: Font?
+
+    public init(value: String, font: Font? = nil) {
+        self.value = value
+        self.font = font
+    }
 }
 
 extension PerMinute: Equatable { }

--- a/Sources/MusicXML/Complex Types/Percussion.swift
+++ b/Sources/MusicXML/Complex Types/Percussion.swift
@@ -15,6 +15,12 @@ public struct Percussion {
     public let printStyleAlign: PrintStyleAlign?
     public let enclosure: EnclosureShape?
     public let kind: Kind
+
+    public init(printStyleAlign: PrintStyleAlign? = nil, enclosure: EnclosureShape? = nil, kind: Kind) {
+        self.printStyleAlign = printStyleAlign
+        self.enclosure = enclosure
+        self.kind = kind
+    }
 }
 
 extension Percussion {

--- a/Sources/MusicXML/Complex Types/Pitch.swift
+++ b/Sources/MusicXML/Complex Types/Pitch.swift
@@ -9,9 +9,15 @@
 /// Pitch is represented as a combination of the step of the diatonic scale, the chromatic
 /// alteration, and the octave.
 public struct Pitch {
-    public var step: Step
-    public var alter: Double?
-    public var octave: Int
+    public let step: Step
+    public let alter: Double?
+    public let octave: Int
+
+    public init(step: Step, alter: Double? = nil, octave: Int) {
+        self.step = step
+        self.alter = alter
+        self.octave = octave
+    }
 }
 
 extension Pitch: Equatable { }

--- a/Sources/MusicXML/Complex Types/PlacementText.swift
+++ b/Sources/MusicXML/Complex Types/PlacementText.swift
@@ -11,6 +11,12 @@ public struct PlacementText {
     public let position: Position
     public let printStyle: PrintStyle
     public let placement: AboveBelow
+
+    public init(position: Position, printStyle: PrintStyle, placement: AboveBelow) {
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension PlacementText: Equatable { }

--- a/Sources/MusicXML/Complex Types/Play.swift
+++ b/Sources/MusicXML/Complex Types/Play.swift
@@ -21,6 +21,10 @@ public struct Play {
     }
 
     public let values: [Kind]
+
+    public init(values: [Kind]) {
+        self.values = values
+    }
 }
 
 extension Play.Kind: Equatable { }

--- a/Sources/MusicXML/Complex Types/Position.swift
+++ b/Sources/MusicXML/Complex Types/Position.swift
@@ -58,10 +58,17 @@
 /// As elsewhere in the MusicXML format, tenths are the global tenths defined by the scaling
 /// element, not the local tenths of a staff resized by the staff-size element.
 public struct Position {
-    public var defaultX: Tenths?
-    public var defaultY: Tenths?
-    public var relativeX: Tenths?
-    public var relativeY: Tenths?
+    public let defaultX: Tenths?
+    public let defaultY: Tenths?
+    public let relativeX: Tenths?
+    public let relativeY: Tenths?
+
+    public init(defaultX: Tenths? = nil, defaultY: Tenths? = nil, relativeX: Tenths? = nil, relativeY: Tenths? = nil) {
+        self.defaultX = defaultX
+        self.defaultY = defaultY
+        self.relativeX = relativeX
+        self.relativeY = relativeY
+    }
 }
 
 extension Position: Equatable { }

--- a/Sources/MusicXML/Complex Types/PrincipleVoice.swift
+++ b/Sources/MusicXML/Complex Types/PrincipleVoice.swift
@@ -14,6 +14,13 @@ public struct PrincipleVoice {
     public let type: StartStop
     public let symbol: PrincipleVoiceSymbol
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(value: String, type: StartStop, symbol: PrincipleVoiceSymbol, printStyleAlign: PrintStyleAlign? = nil) {
+        self.value = value
+        self.type = type
+        self.symbol = symbol
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension PrincipleVoice: Equatable { }

--- a/Sources/MusicXML/Complex Types/Print.swift
+++ b/Sources/MusicXML/Complex Types/Print.swift
@@ -62,4 +62,19 @@ public struct Print: Codable, Equatable {
     let blankPage: Bool?
     let pageNumber: Bool?
     let optionalUniqueID: String
+
+    public init(pageLayout: PageLayout? = nil, systemLayout: SystemLayout? = nil, measureLayout: MeasureLayout? = nil, measureNumbeing: MeasureNumbering? = nil, partNameDisplay: NameDisplay? = nil, partAbbreviationDisplay: NameDisplay? = nil, staffSpacing: Tenths? = nil, newSystem: Bool? = nil, newPage: Bool? = nil, blankPage: Bool? = nil, pageNumber: Bool? = nil, optionalUniqueID: String) {
+        self.pageLayout = pageLayout
+        self.systemLayout = systemLayout
+        self.measureLayout = measureLayout
+        self.measureNumbeing = measureNumbeing
+        self.partNameDisplay = partNameDisplay
+        self.partAbbreviationDisplay = partAbbreviationDisplay
+        self.staffSpacing = staffSpacing
+        self.newSystem = newSystem
+        self.newPage = newPage
+        self.blankPage = blankPage
+        self.pageNumber = pageNumber
+        self.optionalUniqueID = optionalUniqueID
+    }
 }

--- a/Sources/MusicXML/Complex Types/PrintStyle.swift
+++ b/Sources/MusicXML/Complex Types/PrintStyle.swift
@@ -11,6 +11,12 @@ public struct PrintStyle {
     public let position: Position
     public let font: Font
     public let color: Color
+
+    public init(position: Position, font: Font, color: Color) {
+        self.position = position
+        self.font = font
+        self.color = color
+    }
 }
 
 extension PrintStyle: Equatable { }

--- a/Sources/MusicXML/Complex Types/PrintStyleAlign.swift
+++ b/Sources/MusicXML/Complex Types/PrintStyleAlign.swift
@@ -11,6 +11,12 @@ public struct PrintStyleAlign {
     public let printStyle: PrintStyle?
     public let hAlign: LeftCenterRight?
     public let vAlign: VAlign?
+
+    public init(printStyle: PrintStyle? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil) {
+        self.printStyle = printStyle
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+    }
 }
 
 extension PrintStyleAlign: Equatable { }

--- a/Sources/MusicXML/Complex Types/Printout.swift
+++ b/Sources/MusicXML/Complex Types/Printout.swift
@@ -17,6 +17,13 @@ public struct Printout {
     public let printDot: Bool
     public let printSpacing: Bool
     public let printLyric: Bool
+
+    public init(printObject: Bool, printDot: Bool, printSpacing: Bool, printLyric: Bool) {
+        self.printObject = printObject
+        self.printDot = printDot
+        self.printSpacing = printSpacing
+        self.printLyric = printLyric
+    }
 }
 
 extension Printout: Equatable { }

--- a/Sources/MusicXML/Complex Types/Repeat.swift
+++ b/Sources/MusicXML/Complex Types/Repeat.swift
@@ -12,6 +12,12 @@ public struct Repeat {
     public let direction: BackwardForward
     public let times: Int
     public let winged: Winged
+
+    public init(direction: BackwardForward, times: Int, winged: Winged) {
+        self.direction = direction
+        self.times = times
+        self.winged = winged
+    }
 }
 
 extension Repeat: Equatable { }

--- a/Sources/MusicXML/Complex Types/Rest.swift
+++ b/Sources/MusicXML/Complex Types/Rest.swift
@@ -13,6 +13,7 @@ public struct Rest {
 //    public let displayStep: Int?
 //    public let displayOctave: Int?
 //    public let measure: Bool?
+    public init() {}
 }
 
 extension Rest: Equatable { }

--- a/Sources/MusicXML/Complex Types/Rights.swift
+++ b/Sources/MusicXML/Complex Types/Rights.swift
@@ -23,6 +23,11 @@ public struct Rights {
         self.value = value
         self.type = type
     }
+
+    public init(value: String, type: String? = nil) {
+        self.value = value
+        self.type = type
+    }
 }
 
 extension Rights: Equatable { }

--- a/Sources/MusicXML/Complex Types/Root.swift
+++ b/Sources/MusicXML/Complex Types/Root.swift
@@ -12,6 +12,11 @@
 public struct Root {
     public let step: RootStep
     public let alter: RootAlter?
+
+    public init(step: RootStep, alter: RootAlter? = nil) {
+        self.step = step
+        self.alter = alter
+    }
 }
 
 extension Root: Equatable { }

--- a/Sources/MusicXML/Complex Types/RootAlter.swift
+++ b/Sources/MusicXML/Complex Types/RootAlter.swift
@@ -15,6 +15,13 @@ public struct RootAlter {
     public let printStyle: PrintStyle?
     public let location: LeftRight?
 
+
+    public init(value: Double? = nil, printObject: Bool? = nil, printStyle: PrintStyle? = nil, location: LeftRight? = nil) {
+        self.value = value
+        self.printObject = printObject
+        self.printStyle = printStyle
+        self.location = location
+    }
 }
 
 extension RootAlter: Equatable { }

--- a/Sources/MusicXML/Complex Types/RootStep.swift
+++ b/Sources/MusicXML/Complex Types/RootStep.swift
@@ -11,6 +11,12 @@ public struct RootStep {
     public let value: Step
     public let text: String
     public let printStyle: PrintStyle
+
+    public init(value: Step, text: String, printStyle: PrintStyle) {
+        self.value = value
+        self.text = text
+        self.printStyle = printStyle
+    }
 }
 
 extension RootStep: Equatable { }

--- a/Sources/MusicXML/Complex Types/SMuFL.swift
+++ b/Sources/MusicXML/Complex Types/SMuFL.swift
@@ -23,6 +23,10 @@
 public struct SMuFL {
     // TODO: Consider nesting Glyph in here.
     public let glyph: SMuFLGlyph
+
+    public init(glyph: SMuFLGlyph) {
+        self.glyph = glyph
+    }
 }
 
 extension SMuFL: Equatable { }

--- a/Sources/MusicXML/Complex Types/SMuFLGlyph.swift
+++ b/Sources/MusicXML/Complex Types/SMuFLGlyph.swift
@@ -14,6 +14,10 @@
 // <!ENTITY % smufl-glyph-name "NMTOKEN">
 public struct SMuFLGlyph {
     public let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
 }
 
 extension SMuFLGlyph: Equatable { }

--- a/Sources/MusicXML/Complex Types/Scordatura.swift
+++ b/Sources/MusicXML/Complex Types/Scordatura.swift
@@ -9,6 +9,10 @@
 /// staff-tuning elements. Strings are numbered from high to low.
 public struct Scordatura {
     public let accord: [Accord] // NonEmpty
+
+    public init(accord: [Accord]) {
+        self.accord = accord
+    }
 }
 
 extension Scordatura: Equatable { }

--- a/Sources/MusicXML/Complex Types/Score.swift
+++ b/Sources/MusicXML/Complex Types/Score.swift
@@ -37,6 +37,11 @@
 public struct Score {
     public let header: Header
     public let traversal: Traversal
+
+    public init(header: Header, traversal: Traversal) {
+        self.header = header
+        self.traversal = traversal
+    }
 }
 
 extension Score: Equatable { }

--- a/Sources/MusicXML/Complex Types/ScoreInstrument.swift
+++ b/Sources/MusicXML/Complex Types/ScoreInstrument.swift
@@ -21,6 +21,15 @@ public struct ScoreInstrument {
     public var sound: String?
     public var soloOrEnsemble: SoloEnsemble?
     public var virtualInstrument: VirtualInstrument?
+
+    public init(id: String, instrumentName: String, instrumentAbbreviation: String? = nil, sound: String? = nil, soloOrEnsemble: SoloEnsemble? = nil, virtualInstrument: VirtualInstrument? = nil) {
+        self.id = id
+        self.instrumentName = instrumentName
+        self.instrumentAbbreviation = instrumentAbbreviation
+        self.sound = sound
+        self.soloOrEnsemble = soloOrEnsemble
+        self.virtualInstrument = virtualInstrument
+    }
 }
 
 extension ScoreInstrument {

--- a/Sources/MusicXML/Complex Types/ScorePart.swift
+++ b/Sources/MusicXML/Complex Types/ScorePart.swift
@@ -71,6 +71,18 @@ public struct ScorePart {
     /// element within a part. The id attribute refers to the score-instrument affected by the
     /// change.
     public var midi: [MIDI]?
+
+    public init(id: String, identification: Identification? = nil, name: PartName, nameDisplay: NameDisplay? = nil, partAbbreviation: PartName? = nil, partAbbreviationDisplay: NameDisplay? = nil, group: [String]? = nil, scoreInstrument: [ScoreInstrument]? = nil, midi: [MIDI]? = nil) {
+        self.id = id
+        self.identification = identification
+        self.name = name
+        self.nameDisplay = nameDisplay
+        self.partAbbreviation = partAbbreviation
+        self.partAbbreviationDisplay = partAbbreviationDisplay
+        self.group = group
+        self.scoreInstrument = scoreInstrument
+        self.midi = midi
+    }
 }
 
 extension ScorePart {
@@ -85,6 +97,11 @@ extension ScorePart {
         /// the sound element within a part. The id attribute refers to the score-instrument
         /// affected by the change.
         public let midiInstrument: MIDIInstrument?
+
+        public init(midiDevice: MIDIDevice? = nil, midiInstrument: MIDIInstrument? = nil) {
+            self.midiDevice = midiDevice
+            self.midiInstrument = midiInstrument
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Slash.swift
+++ b/Sources/MusicXML/Complex Types/Slash.swift
@@ -21,6 +21,14 @@ public struct Slash {
     /// The slash-dot element is used to specify any augmentation dots in the note type used to
     /// display repetition marks.
     public let slashDot: [Empty]
+
+    public init(type: StartStop, useDots: Bool? = nil, useStems: Bool? = nil, slashType: NoteTypeValue, slashDot: [Empty]) {
+        self.type = type
+        self.useDots = useDots
+        self.useStems = useStems
+        self.slashType = slashType
+        self.slashDot = slashDot
+    }
 }
 
 extension Slash: Equatable { }

--- a/Sources/MusicXML/Complex Types/Slide.swift
+++ b/Sources/MusicXML/Complex Types/Slide.swift
@@ -17,6 +17,16 @@ public struct Slide {
     public let dashedFormatting: DashedFormatting?
     public let printStyle: PrintStyle?
     public let bendSound: BendSound?
+
+    public init(value: String, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, printStyle: PrintStyle? = nil, bendSound: BendSound? = nil) {
+        self.value = value
+        self.type = type
+        self.number = number
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.printStyle = printStyle
+        self.bendSound = bendSound
+    }
 }
 
 extension Slide: Equatable { }

--- a/Sources/MusicXML/Complex Types/Slur.swift
+++ b/Sources/MusicXML/Complex Types/Slur.swift
@@ -18,6 +18,18 @@ public struct Slur {
     public let orientation: OverUnder?
     public let bezier: Bezier?
     public let color: Color?
+
+    public init(type: StartStopContinue, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, position: Position? = nil, placement: AboveBelow? = nil, orientation: OverUnder? = nil, bezier: Bezier? = nil, color: Color? = nil) {
+        self.type = type
+        self.number = number
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.position = position
+        self.placement = placement
+        self.orientation = orientation
+        self.bezier = bezier
+        self.color = color
+    }
 }
 
 extension Slur: Equatable { }

--- a/Sources/MusicXML/Complex Types/Sound.swift
+++ b/Sources/MusicXML/Complex Types/Sound.swift
@@ -43,6 +43,28 @@ public struct Sound {
     public let sostenutoPedal: YesNoNumber?
     public let offset: Offset?
     public let midi: [MIDI]
+
+    public init(tempo: Double? = nil, dynamics: Double? = nil, dacapo: Bool? = nil, segno: String? = nil, dalsegno: String? = nil, coda: String? = nil, tocoda: String? = nil, divisions: Divisions? = nil, forwardRepeat: Bool? = nil, fine: String? = nil, timeOnly: TimeOnly? = nil, pizzicato: Bool? = nil, pan: Double? = nil, elevation: Double? = nil, damperPedal: YesNoNumber? = nil, softPedal: YesNoNumber? = nil, sostenutoPedal: YesNoNumber? = nil, offset: Offset? = nil, midi: [MIDI]) {
+        self.tempo = tempo
+        self.dynamics = dynamics
+        self.dacapo = dacapo
+        self.segno = segno
+        self.dalsegno = dalsegno
+        self.coda = coda
+        self.tocoda = tocoda
+        self.divisions = divisions
+        self.forwardRepeat = forwardRepeat
+        self.fine = fine
+        self.timeOnly = timeOnly
+        self.pizzicato = pizzicato
+        self.pan = pan
+        self.elevation = elevation
+        self.damperPedal = damperPedal
+        self.softPedal = softPedal
+        self.sostenutoPedal = sostenutoPedal
+        self.offset = offset
+        self.midi = midi
+    }
 }
 
 extension Sound {
@@ -64,6 +86,12 @@ extension Sound {
         /// affected instrument should be specified using the id attribute. When used as part of a
         /// note element, it applies to the current note only.
         public let play: Play?
+
+        public init(midiDevice: MIDIDevice? = nil, midiInstrument: MIDIInstrument? = nil, play: Play? = nil) {
+            self.midiDevice = midiDevice
+            self.midiInstrument = midiInstrument
+            self.play = play
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/StaffDetails.swift
+++ b/Sources/MusicXML/Complex Types/StaffDetails.swift
@@ -44,6 +44,18 @@ public struct StaffDetails {
     /// unless specified here. Staff size affects staff height only, not the relationship of the
     /// staff to the left and right margins.
     public let staffSize: Double?
+
+    public init(number: Int? = nil, showFrets: ShowFrets? = nil, printObject: Bool? = nil, printSpacing: Bool? = nil, staffType: StaffType? = nil, staffLines: Int? = nil, staffTuning: [StaffTuning], capo: Int? = nil, staffSize: Double? = nil) {
+        self.number = number
+        self.showFrets = showFrets
+        self.printObject = printObject
+        self.printSpacing = printSpacing
+        self.staffType = staffType
+        self.staffLines = staffLines
+        self.staffTuning = staffTuning
+        self.capo = capo
+        self.staffSize = staffSize
+    }
 }
 
 extension StaffDetails: Equatable { }

--- a/Sources/MusicXML/Complex Types/StaffLayout.swift
+++ b/Sources/MusicXML/Complex Types/StaffLayout.swift
@@ -9,6 +9,11 @@
 public struct StaffLayout {
     public let number: Int?
     public let staffDistance: Tenths?
+
+    public init(number: Int? = nil, staffDistance: Tenths? = nil) {
+        self.number = number
+        self.staffDistance = staffDistance
+    }
 }
 
 extension StaffLayout: Equatable { }

--- a/Sources/MusicXML/Complex Types/StaffTuning.swift
+++ b/Sources/MusicXML/Complex Types/StaffTuning.swift
@@ -12,6 +12,13 @@ public struct StaffTuning {
     public let tuningAlter: Double?
     public let tuningOctave: Int
 
+
+    public init(line: Int? = nil, tuningStep: Step, tuningAlter: Double? = nil, tuningOctave: Int) {
+        self.line = line
+        self.tuningStep = tuningStep
+        self.tuningAlter = tuningAlter
+        self.tuningOctave = tuningOctave
+    }
 }
 
 extension StaffTuning: Equatable { }

--- a/Sources/MusicXML/Complex Types/Stem.swift
+++ b/Sources/MusicXML/Complex Types/Stem.swift
@@ -11,9 +11,15 @@
 /// relative-y that would flip a stem instead of shortening it are ignored. A stem element
 /// associated with a rest refers to a stemlet.
 public struct Stem {
-    public var value: StemValue
-    public var position: Position = Position()
-    public var color: Color?
+    public let value: StemValue
+    public let position: Position
+    public let color: Color?
+
+    public init(value: StemValue, position: Position = Position(), color: Color? = nil) {
+        self.value = value
+        self.position = position
+        self.color = color
+    }
 }
 
 extension Stem: Equatable { }

--- a/Sources/MusicXML/Complex Types/Stick.swift
+++ b/Sources/MusicXML/Complex Types/Stick.swift
@@ -11,6 +11,12 @@ public struct Stick {
     public let tip: TipDirection?
     public let stickType: StickType
     public let stickMaterial: StickMaterial
+
+    public init(tip: TipDirection? = nil, stickType: StickType, stickMaterial: StickMaterial) {
+        self.tip = tip
+        self.stickType = stickType
+        self.stickMaterial = stickMaterial
+    }
 }
 
 extension Stick: Equatable { }

--- a/Sources/MusicXML/Complex Types/StringMute.swift
+++ b/Sources/MusicXML/Complex Types/StringMute.swift
@@ -9,6 +9,11 @@
 public struct StringMute {
     public let type: OnOff
     public let printStyleAlign: PrintStyleAlign?
+
+    public init(type: OnOff, printStyleAlign: PrintStyleAlign? = nil) {
+        self.type = type
+        self.printStyleAlign = printStyleAlign
+    }
 }
 
 extension StringMute: Equatable { }

--- a/Sources/MusicXML/Complex Types/StringNumber.swift
+++ b/Sources/MusicXML/Complex Types/StringNumber.swift
@@ -9,6 +9,10 @@
 /// being the highest pitched string.
 public struct StringNumber {
     public let value: Int
+
+    public init(value: Int) {
+        self.value = value
+    }
 }
 
 extension StringNumber: Equatable { }

--- a/Sources/MusicXML/Complex Types/StrongAccent.swift
+++ b/Sources/MusicXML/Complex Types/StrongAccent.swift
@@ -11,6 +11,13 @@ public struct StrongAccent {
     public let position: Position
     public let printStyle: PrintStyle
     public let placement: AboveBelow
+
+    public init(type: UpDown, position: Position, printStyle: PrintStyle, placement: AboveBelow) {
+        self.type = type
+        self.position = position
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension StrongAccent: Equatable { }

--- a/Sources/MusicXML/Complex Types/StyleText.swift
+++ b/Sources/MusicXML/Complex Types/StyleText.swift
@@ -9,6 +9,11 @@
 public struct StyleText {
     public let value: String
     public let printStyle: PrintStyle?
+
+    public init(value: String, printStyle: PrintStyle? = nil) {
+        self.value = value
+        self.printStyle = printStyle
+    }
 }
 
 extension StyleText: Equatable { }

--- a/Sources/MusicXML/Complex Types/Supports.swift
+++ b/Sources/MusicXML/Complex Types/Supports.swift
@@ -16,6 +16,13 @@ public struct Supports {
     public let element: String
     public let attribute: String?
     public let value: String?
+
+    public init(type: Bool, element: String, attribute: String? = nil, value: String? = nil) {
+        self.type = type
+        self.element = element
+        self.attribute = attribute
+        self.value = value
+    }
 }
 
 extension Supports: Equatable { }

--- a/Sources/MusicXML/Complex Types/SystemDividers.swift
+++ b/Sources/MusicXML/Complex Types/SystemDividers.swift
@@ -15,6 +15,11 @@
 public struct SystemDividers {
     public let left: EmptyPrintObjectStyleAlign
     public let right: EmptyPrintObjectStyleAlign
+
+    public init(left: EmptyPrintObjectStyleAlign, right: EmptyPrintObjectStyleAlign) {
+        self.left = left
+        self.right = right
+    }
 }
 
 extension SystemDividers: Equatable { }

--- a/Sources/MusicXML/Complex Types/SystemLayout.swift
+++ b/Sources/MusicXML/Complex Types/SystemLayout.swift
@@ -20,6 +20,13 @@ public struct SystemLayout {
     public let systemDistance: Tenths
     public let topSystemDistance: Int?
     public let systemDividers: SystemDividers?
+
+    public init(systemMargins: SystemMargins? = nil, systemDistance: Tenths, topSystemDistance: Int? = nil, systemDividers: SystemDividers? = nil) {
+        self.systemMargins = systemMargins
+        self.systemDistance = systemDistance
+        self.topSystemDistance = topSystemDistance
+        self.systemDividers = systemDividers
+    }
 }
 
 extension SystemLayout: Equatable { }

--- a/Sources/MusicXML/Complex Types/SystemMargins.swift
+++ b/Sources/MusicXML/Complex Types/SystemMargins.swift
@@ -10,6 +10,11 @@
 public struct SystemMargins {
     public let left: Tenths
     public let right: Tenths
+
+    public init(left: Tenths, right: Tenths) {
+        self.left = left
+        self.right = right
+    }
 }
 
 extension SystemMargins: Equatable { }

--- a/Sources/MusicXML/Complex Types/Technical.swift
+++ b/Sources/MusicXML/Complex Types/Technical.swift
@@ -8,6 +8,10 @@
 /// Technical indications give performance information for individual instruments.
 public struct Technical {
     public let values: [Technique]
+
+    public init(values: [Technique]) {
+        self.values = values
+    }
 }
 
 extension Technical: Equatable { }

--- a/Sources/MusicXML/Complex Types/TextDecoration.swift
+++ b/Sources/MusicXML/Complex Types/TextDecoration.swift
@@ -12,6 +12,12 @@ public struct TextDecoration {
     public let underline: Int
     public let overline: Int
     public let lineThrough: Int
+
+    public init(underline: Int, overline: Int, lineThrough: Int) {
+        self.underline = underline
+        self.overline = overline
+        self.lineThrough = lineThrough
+    }
 }
 
 extension TextDecoration: Equatable { }

--- a/Sources/MusicXML/Complex Types/TextElementData.swift
+++ b/Sources/MusicXML/Complex Types/TextElementData.swift
@@ -16,6 +16,15 @@ public struct TextElementData {
     public let textRotation: Double?
     public let letterSpacing: NumberOrNormal?
     public let dir: TextDirection?
+
+    public init(font: Font? = nil, color: Color? = nil, textDecoration: TextDecoration? = nil, textRotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, dir: TextDirection? = nil) {
+        self.font = font
+        self.color = color
+        self.textDecoration = textDecoration
+        self.textRotation = textRotation
+        self.letterSpacing = letterSpacing
+        self.dir = dir
+    }
 }
 
 extension TextElementData: Equatable { }

--- a/Sources/MusicXML/Complex Types/TextFontColor.swift
+++ b/Sources/MusicXML/Complex Types/TextFontColor.swift
@@ -15,6 +15,16 @@ public struct TextFontColor {
     public let textRotation: Double?
     public let letterSpacing: NumberOrNormal?
     public let dir: TextDirection?
+
+    public init(value: String, font: Font? = nil, color: Color? = nil, textDecoration: TextDecoration? = nil, textRotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, dir: TextDirection? = nil) {
+        self.value = value
+        self.font = font
+        self.color = color
+        self.textDecoration = textDecoration
+        self.textRotation = textRotation
+        self.letterSpacing = letterSpacing
+        self.dir = dir
+    }
 }
 
 extension TextFontColor: Equatable { }

--- a/Sources/MusicXML/Complex Types/Tie.swift
+++ b/Sources/MusicXML/Complex Types/Tie.swift
@@ -10,6 +10,11 @@
 public struct Tie {
     public var type: StartStop
     public var timeOnly: TimeOnly?
+
+    public init(type: StartStop, timeOnly: TimeOnly? = nil) {
+        self.type = type
+        self.timeOnly = timeOnly
+    }
 }
 
 extension Tie: Equatable { }

--- a/Sources/MusicXML/Complex Types/Tied.swift
+++ b/Sources/MusicXML/Complex Types/Tied.swift
@@ -16,6 +16,18 @@ public struct Tied {
     public var orientation: OverUnder?
     public var bezier: Bezier?
     public var color: Color?
+
+    public init(type: StartStopContinue, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, position: Position? = nil, placement: AboveBelow? = nil, orientation: OverUnder? = nil, bezier: Bezier? = nil, color: Color? = nil) {
+        self.type = type
+        self.number = number
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.position = position
+        self.placement = placement
+        self.orientation = orientation
+        self.bezier = bezier
+        self.color = color
+    }
 }
 
 extension Tied: Equatable { }

--- a/Sources/MusicXML/Complex Types/Time.swift
+++ b/Sources/MusicXML/Complex Types/Time.swift
@@ -19,11 +19,11 @@ public struct Time {
 
     /// The optional number attribute refers to staff numbers within the part. If absent, the
     /// time signature applies to all staves in the part.
-    public var number: Int?
+    public let number: Int?
 
     /// The symbol attribute is used indicate common and cut time symbols as well as a single number
     /// display.
-    public var symbol: TimeSymbol?
+    public let symbol: TimeSymbol?
 
     /// The time-separator attribute indicates how to display the arrangement between the beats and
     /// beat-type values in a time signature. The default value is none. The horizontal, diagonal,
@@ -32,16 +32,27 @@ public struct Time {
     /// side of the separator line. The none value represents  no separator with the beats and
     /// beat-type arranged vertically. The adjacent value represents no separator with the beats and
     /// beat-type arranged horizontally.
-    public var separator: TimeSeparator?
+    public let separator: TimeSeparator?
 
-    public var printStyle: PrintStyle?
-    public var hAlign: LeftCenterRight?
-    public var vAlign: VAlign?
-    public var printObject: Bool?
+    public let printStyle: PrintStyle?
+    public let hAlign: LeftCenterRight?
+    public let vAlign: VAlign?
+    public let printObject: Bool?
 
     // MARK: - Elements
 
-    public var kind: Kind
+    public let kind: Kind
+
+    public init(number: Int? = nil, symbol: TimeSymbol? = nil, separator: TimeSeparator? = nil, printStyle: PrintStyle? = nil, hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil, printObject: Bool? = nil, kind: Kind) {
+        self.number = number
+        self.symbol = symbol
+        self.separator = separator
+        self.printStyle = printStyle
+        self.hAlign = hAlign
+        self.vAlign = vAlign
+        self.printObject = printObject
+        self.kind = kind
+    }
 }
 
 extension Time {
@@ -72,6 +83,11 @@ extension Time {
             )
         )
         // TODO: Add remaining attributes and elements
+        self.separator = nil
+        self.printStyle = nil
+        self.hAlign = nil
+        self.vAlign = nil
+        self.printObject = nil
     }
 
     /// Creates an `Unmeasured` type `Time`.
@@ -84,6 +100,13 @@ extension Time {
         self.number = staff
         self.kind = .unmeasured(Unmeasured(symbol: symbol))
         // TODO: Add remaining attributes and elements
+        // TODO: correct symbol
+        self.symbol = nil
+        self.separator = nil
+        self.printStyle = nil
+        self.hAlign = nil
+        self.vAlign = nil
+        self.printObject = nil
     }
 }
 
@@ -92,6 +115,11 @@ extension Time {
     public struct Signature {
         let beats: Int
         let beatType: Int
+
+        public init(beats: Int, beatType: Int) {
+            self.beats = beats
+            self.beatType = beatType
+        }
     }
 
     // > Time signatures are represented by two elements. The
@@ -114,6 +142,11 @@ extension Time {
         #warning("Handle multiple time signatures in Time.Measured")
         var signature: Signature
         var interchangeable: Interchangeable?
+
+        public init(signature: Signature, interchangeable: Interchangeable? = nil) {
+            self.signature = signature
+            self.interchangeable = interchangeable
+        }
     }
 
     // > A senza-misura element explicitly indicates that no time
@@ -123,6 +156,10 @@ extension Time {
     // > senza-misura element is present.
     public struct Unmeasured {
         let symbol: String?
+
+        public init(symbol: String? = nil) {
+            self.symbol = symbol
+        }
     }
 
     public enum Kind {

--- a/Sources/MusicXML/Complex Types/TimeModification.swift
+++ b/Sources/MusicXML/Complex Types/TimeModification.swift
@@ -23,6 +23,13 @@ public struct TimeModification {
     public var normalType: NoteTypeValue?
     /// The normal-dot element is used to specify dotted normal tuplet types.
     public var normalDot: [Empty]?
+
+    public init(actualNotes: Int, normalNotes: Int, normalType: NoteTypeValue? = nil, normalDot: [Empty]? = nil) {
+        self.actualNotes = actualNotes
+        self.normalNotes = normalNotes
+        self.normalType = normalType
+        self.normalDot = normalDot
+    }
 }
 
 extension TimeModification: Equatable { }

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.Measure.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.Measure.swift
@@ -58,6 +58,16 @@ extension Timewise {
         let width: Tenths?
         let optionalUniqueID: Int?
         let parts: [Part]
+
+        public init(number: Int, text: String? = nil, implicit: Bool? = nil, nonControlling: Bool? = nil, width: Tenths? = nil, optionalUniqueID: Int? = nil, parts: [Part]) {
+            self.number = number
+            self.text = text
+            self.implicit = implicit
+            self.nonControlling = nonControlling
+            self.width = width
+            self.optionalUniqueID = optionalUniqueID
+            self.parts = parts
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.Part.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.Part.swift
@@ -19,6 +19,11 @@ extension Timewise {
     public struct Part {
         public var id: String
         public var musicData: [MusicData]
+
+        public init(id: String, musicData: [MusicData]) {
+            self.id = id
+            self.musicData = musicData
+        }
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
@@ -21,6 +21,16 @@ public struct Timewise {
 
     /// The `Measure` values which comprise a `Timewise` traversal of a `MusicXML` score.
     let measures: [Measure]
+
+    public init(work: Work? = nil, movementNumber: String? = nil, movementTitle: String? = nil, identification: Identification? = nil, defaults: Defaults? = nil, credits: [Credit]? = nil, measures: [Measure]) {
+        self.work = work
+        self.movementNumber = movementNumber
+        self.movementTitle = movementTitle
+        self.identification = identification
+        self.defaults = defaults
+        self.credits = credits
+        self.measures = measures
+    }
 }
 
 extension Timewise: Equatable { }

--- a/Sources/MusicXML/Complex Types/Transpose.swift
+++ b/Sources/MusicXML/Complex Types/Transpose.swift
@@ -31,6 +31,14 @@ public struct Transpose {
     /// from what is currently written (as is the case for mixed cello / bass parts in orchestral
     /// literature).
     public let double: Bool
+
+    public init(number: Int? = nil, diatonic: Int? = nil, chromatic: Int, octaveChange: Int, double: Bool) {
+        self.number = number
+        self.diatonic = diatonic
+        self.chromatic = chromatic
+        self.octaveChange = octaveChange
+        self.double = double
+    }
 }
 
 extension Transpose: Equatable { }

--- a/Sources/MusicXML/Complex Types/Tremolo.swift
+++ b/Sources/MusicXML/Complex Types/Tremolo.swift
@@ -20,6 +20,13 @@ public struct Tremolo {
     public let type: StartStopSingle?
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
+
+    public init(marks: Int, type: StartStopSingle? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+        self.marks = marks
+        self.type = type
+        self.printStyle = printStyle
+        self.placement = placement
+    }
 }
 
 extension Tremolo: Equatable { }

--- a/Sources/MusicXML/Complex Types/TrillSound.swift
+++ b/Sources/MusicXML/Complex Types/TrillSound.swift
@@ -32,4 +32,14 @@ public struct TrillSound: Codable, Equatable {
     let beats: Int
     let secondBeat: Int
     let lastBeat: Int
+
+    public init(startNote: StartNote, trillStep: TrillStep, twoNoteTurn: TwoNoteTurn, accelerate: Bool, beats: Int, secondBeat: Int, lastBeat: Int) {
+        self.startNote = startNote
+        self.trillStep = trillStep
+        self.twoNoteTurn = twoNoteTurn
+        self.accelerate = accelerate
+        self.beats = beats
+        self.secondBeat = secondBeat
+        self.lastBeat = lastBeat
+    }
 }

--- a/Sources/MusicXML/Complex Types/Tuplet.swift
+++ b/Sources/MusicXML/Complex Types/Tuplet.swift
@@ -38,6 +38,19 @@ public struct Tuplet {
 
     public var actualNotes: TupletPortion?
     public var normalNotes: TupletPortion?
+
+    public init(type: StartStop, number: Int? = nil, bracket: Bool? = nil, showNumber: ShowTuplet? = nil, showType: ShowTuplet? = nil, lineShape: LineShape? = nil, position: Position? = nil, placement: AboveBelow? = nil, actualNotes: TupletPortion? = nil, normalNotes: TupletPortion? = nil) {
+        self.type = type
+        self.number = number
+        self.bracket = bracket
+        self.showNumber = showNumber
+        self.showType = showType
+        self.lineShape = lineShape
+        self.position = position
+        self.placement = placement
+        self.actualNotes = actualNotes
+        self.normalNotes = normalNotes
+    }
 }
 
 extension Tuplet: Equatable { }

--- a/Sources/MusicXML/Complex Types/TupletDot.swift
+++ b/Sources/MusicXML/Complex Types/TupletDot.swift
@@ -9,6 +9,11 @@
 public struct TupletDot {
     public let font: Font?
     public let color: Color?
+
+    public init(font: Font? = nil, color: Color? = nil) {
+        self.font = font
+        self.color = color
+    }
 }
 
 extension TupletDot: Equatable { }

--- a/Sources/MusicXML/Complex Types/TupletNumber.swift
+++ b/Sources/MusicXML/Complex Types/TupletNumber.swift
@@ -10,6 +10,12 @@ public struct TupletNumber {
     public let value: Int
     public let font: Font?
     public let color: Color?
+
+    public init(value: Int, font: Font? = nil, color: Color? = nil) {
+        self.value = value
+        self.font = font
+        self.color = color
+    }
 }
 
 extension TupletNumber: Equatable { }

--- a/Sources/MusicXML/Complex Types/TupletPortion.swift
+++ b/Sources/MusicXML/Complex Types/TupletPortion.swift
@@ -13,6 +13,12 @@ public struct TupletPortion {
     public let tupletNumber: TupletNumber?
     public let tupletType: TupletType?
     public let tupletDot: [TupletDot]
+
+    public init(tupletNumber: TupletNumber? = nil, tupletType: TupletType? = nil, tupletDot: [TupletDot]) {
+        self.tupletNumber = tupletNumber
+        self.tupletType = tupletType
+        self.tupletDot = tupletDot
+    }
 }
 
 extension TupletPortion: Equatable { }

--- a/Sources/MusicXML/Complex Types/TupletType.swift
+++ b/Sources/MusicXML/Complex Types/TupletType.swift
@@ -11,6 +11,12 @@ public struct TupletType {
     public let value: NoteTypeValue
     public let font: Font?
     public let color: Color?
+
+    public init(value: NoteTypeValue, font: Font? = nil, color: Color? = nil) {
+        self.value = value
+        self.font = font
+        self.color = color
+    }
 }
 
 extension TupletType: Equatable { }

--- a/Sources/MusicXML/Complex Types/Unpitched.swift
+++ b/Sources/MusicXML/Complex Types/Unpitched.swift
@@ -10,6 +10,11 @@
 public struct Unpitched {
     public var displayStep: Step
     public var displayOctave: Int
+
+    public init(displayStep: Step, displayOctave: Int) {
+        self.displayStep = displayStep
+        self.displayOctave = displayOctave
+    }
 }
 
 extension Unpitched: Equatable { }

--- a/Sources/MusicXML/Complex Types/VirtualInstrument.swift
+++ b/Sources/MusicXML/Complex Types/VirtualInstrument.swift
@@ -10,6 +10,11 @@
 public struct VirtualInstrument {
     public let library: String?
     public let name: String?
+
+    public init(library: String? = nil, name: String? = nil) {
+        self.library = library
+        self.name = name
+    }
 }
 
 extension VirtualInstrument: Equatable { }

--- a/Sources/MusicXML/Complex Types/WavyLine.swift
+++ b/Sources/MusicXML/Complex Types/WavyLine.swift
@@ -14,6 +14,15 @@ public struct WavyLine {
     public let placement: AboveBelow?
     public let color: Color?
     public let trillSound: TrillSound?
+
+    public init(type: StartStopContinue, number: Int? = nil, position: Position? = nil, placement: AboveBelow? = nil, color: Color? = nil, trillSound: TrillSound? = nil) {
+        self.type = type
+        self.number = number
+        self.position = position
+        self.placement = placement
+        self.color = color
+        self.trillSound = trillSound
+    }
 }
 
 extension WavyLine: Equatable { }

--- a/Sources/MusicXML/Complex Types/Wedge.swift
+++ b/Sources/MusicXML/Complex Types/Wedge.swift
@@ -24,6 +24,17 @@ public struct Wedge {
     public let dashedFormatting: DashedFormatting?
     public let position: Position?
     public let color: Color?
+
+    public init(type: WedgeType, number: Int? = nil, spread: Tenths? = nil, niente: Bool? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, position: Position? = nil, color: Color? = nil) {
+        self.type = type
+        self.number = number
+        self.spread = spread
+        self.niente = niente
+        self.lineType = lineType
+        self.dashedFormatting = dashedFormatting
+        self.position = position
+        self.color = color
+    }
 }
 
 extension Wedge: Equatable { }

--- a/Sources/MusicXML/Complex Types/Work.swift
+++ b/Sources/MusicXML/Complex Types/Work.swift
@@ -11,6 +11,12 @@ public struct Work {
     public let number: String?
     public let title: String?
     public let opus: Opus?
+
+    public init(number: String? = nil, title: String? = nil, opus: Opus? = nil) {
+        self.number = number
+        self.title = title
+        self.opus = opus
+    }
 }
 
 extension Work: Equatable { }

--- a/Sources/MusicXML/Output/PublicInitializer.generated.swift
+++ b/Sources/MusicXML/Output/PublicInitializer.generated.swift
@@ -1,0 +1,3 @@
+// Generated using Sourcery 0.17.0 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+

--- a/Sources/MusicXML/Templates/Initializer.stencil
+++ b/Sources/MusicXML/Templates/Initializer.stencil
@@ -1,0 +1,13 @@
+{# A template to generate initializer inline #}
+{# Example: $sourcery --sources Complex\ Types/Accidental.swift --templates Templates/ --output Output/ #}
+{% for type in types.structs %}
+{% set spacing %}{% if type.parentName %}    {% endif %}{% endset %}
+{% map type.storedVariables into parameters using var %}{{ var.name }}: {{ var.typeName }}{% if var.defaultValue %} = {{var.defaultValue}}{% elif var.typeName.isOptional %} = nil{% endif %}{% endmap %}
+// sourcery:inline:auto:{{ type.name }}.AutoInit
+{{spacing}}    {{ type.accessLevel }} init({{ parameters|join:", " }}) {
+{{spacing}}        {% for variable in type.storedVariables %}
+{{spacing}}        self.{{ variable.name }} = {{ variable.name }}
+{{spacing}}        {% endfor %}
+{{spacing}}    }
+// sourcery:end
+{% endfor %}

--- a/Tests/MusicXMLTests/Initializers/PartWiseInitializerTests.swift
+++ b/Tests/MusicXMLTests/Initializers/PartWiseInitializerTests.swift
@@ -1,0 +1,76 @@
+//
+//  PartWiseInitializerTests.swift
+//  MusicXMLTests
+//
+//  Created by Ben Lu on 10/3/19.
+//
+
+import XCTest
+// Do not use @testable
+import MusicXML
+
+class PartWiseInitializerTests: XCTestCase {
+    func testPartWise() {
+        _ = Partwise.Measure(
+            number: 2,
+            width: 474.15,
+            musicData: [
+                .attributes(
+                    Attributes(
+                        divisions: 4,
+                        keys: [Key(fifths: 2)],
+                        times: [Time(4, 4)],
+                        clefs: [Clef(sign: .g, line: 2)]
+                    )
+                ),
+                .direction(
+                    Direction(
+                        placement: .above,
+                        directive: nil,
+                        directionType: .metronome(
+                            Metronome(
+                                kind: .regular(
+                                    Metronome.Regular(
+                                        beatUnit: .quarter,
+                                        beatUnitDot: [],
+                                        relation: .perMinute(
+                                            PerMinute(value: "90", font: nil)
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+                .note(
+                  Note(
+                    kind: .normal(
+                      Note.Normal(
+                        pitchUnpitchedOrRest: .rest(Rest()),
+                        duration: 4
+                      )
+                    ),
+                    voice: "1",
+                    type: NoteType(value: .quarter)
+                  )
+                ),
+                .note(
+                    Note(
+                        kind: .normal(
+                            Note.Normal(
+                                pitchUnpitchedOrRest: .pitch(
+                                    Pitch(step: .d, alter: nil, octave: 4)
+                                ),
+                                duration: 8
+                            )
+                        ),
+                        position: Position(defaultX: 10, defaultY: -45),
+                        voice: "1",
+                        type: NoteType(value: .half),
+                        stem: Stem(value: .up)
+                    )
+                ),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Create a Sourcery stencil 
https://github.com/dn-m/MusicXML/pull/106/files?file-filters%5B%5D=.stencil#diff-31d2d89e92cdf1bb2e5e3a504b9c3bc3 and used it to generate all the initializers under `Complex Types`.

In the future people can run 
```bash
sourcery --sources path/to/file.swift --templates Templates/ --output Output/
```
to autogen initailizers.

The stencil is smart - it fills default value if the property has a default value provided, and it default property to `nil` if the property is nullable.