### PR TITLE
Specify Ornament error

### DIFF
--- a/Sources/MusicXML/Complex Types/Ornament.swift
+++ b/Sources/MusicXML/Complex Types/Ornament.swift
@@ -75,54 +75,38 @@ extension Ornament: Codable {
             return try container.decode(T.self, forKey: key)
         }
 
-        do {
+        if container.contains(.delayedInvertedTurn) {
             self = .delayedInvertedTurn(try decode(.delayedInvertedTurn))
-        } catch {
-            do {
-                self = .delayedTurn(try decode(.delayedTurn))
-            } catch {
-                do {
-                    self = .invertedMordent(try decode(.invertedMordent))
-                } catch {
-                    do {
-                        self = .invertedTurn(try decode(.invertedTurn))
-                    } catch {
-                        do {
-                            self = .mordent(try decode(.mordent))
-                        } catch {
-                            do {
-                                self = .otherOrnament(try decode(.otherOrnament))
-                            } catch {
-                                do {
-                                    self = .shake(try decode(.shake))
-                                } catch {
-                                    do {
-                                        self = .tremolo(try decode(.tremolo))
-                                    } catch {
-                                        do {
-                                            self = .trillMark(try decode(.trillMark))
-                                        } catch {
-                                            do {
-                                                self = .turn(try decode(.turn))
-                                            } catch {
-                                                do {
-                                                    self = .verticalTurn(try decode(.verticalTurn))
-                                                } catch {
-                                                    do {
-                                                        self = .wavyLine(try decode(.wavyLine))
-                                                    } catch DecodingError.typeMismatch(_, let context) {
-                                                        throw DecodingError.typeMismatch(Ornament.self, context)
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        } else if container.contains(.delayedTurn) {
+            self = .delayedTurn(try decode(.delayedTurn))
+        } else if container.contains(.invertedMordent) {
+            self = .invertedMordent(try decode(.invertedMordent))
+        } else if container.contains(.invertedTurn) {
+            self = .invertedTurn(try decode(.invertedTurn))
+        } else if container.contains(.mordent) {
+            self = .mordent(try decode(.mordent))
+        } else if container.contains(.otherOrnament) {
+            self = .otherOrnament(try decode(.otherOrnament))
+        } else if container.contains(.shake) {
+            self = .shake(try decode(.shake))
+        } else if container.contains(.tremolo) {
+            self = .tremolo(try decode(.tremolo))
+        } else if container.contains(.trillMark) {
+            self = .trillMark(try decode(.trillMark))
+        } else if container.contains(.turn) {
+            self = .turn(try decode(.turn))
+        } else if container.contains(.verticalTurn) {
+            self = .verticalTurn(try decode(.verticalTurn))
+        } else if container.contains(.wavyLine) {
+            self = .wavyLine(try decode(.wavyLine))
+        } else {
+            throw DecodingError.typeMismatch(
+                Ornament.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unrecognized choice"
+                )
+            )
         }
     }
 }

--- a/Sources/MusicXML/Complex Types/Ornament.swift
+++ b/Sources/MusicXML/Complex Types/Ornament.swift
@@ -108,7 +108,11 @@ extension Ornament: Codable {
                                                 do {
                                                     self = .verticalTurn(try decode(.verticalTurn))
                                                 } catch {
-                                                    self = .wavyLine(try decode(.wavyLine))
+                                                    do {
+                                                        self = .wavyLine(try decode(.wavyLine))
+                                                    } catch DecodingError.typeMismatch(_, let context) {
+                                                        throw DecodingError.typeMismatch(Ornament.self, context)
+                                                    }
                                                 }
                                             }
                                         }

--- a/Sources/MusicXML/Complex Types/Ornaments.swift
+++ b/Sources/MusicXML/Complex Types/Ornaments.swift
@@ -33,7 +33,7 @@ extension Ornaments: Codable {
         while !valuesContainer.isAtEnd {
             do {
                 ornaments.append(try valuesContainer.decode(Ornament.self))
-            } catch {
+            } catch DecodingError.typeMismatch(let type, _) where type == Ornament.self {
                 // Error is caught when we try to read an accidental-mark as an ornament.
                 break
             }


### PR DESCRIPTION
Wondering if this pattern is more in line with your thinking, @DJBen. If this is valid, perhaps we could use this throwing structure for other choice elements, so that we are not consistently rethrowing the `typeMismatch` error of whatever case is the last in the `do`-`catch` pyramid. @jsbean 