### PR TITLE
Fix metronome decoding when the beat-unit appears twice in sequence s…

### DIFF
--- a/Sources/MusicXML/Complex Types/HarmonyChord.swift
+++ b/Sources/MusicXML/Complex Types/HarmonyChord.swift
@@ -87,7 +87,7 @@ public struct HarmonyChord {
             }
         }
         guard let rootOrFunction = aRootOrFunction else {
-            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires at root or function to be present"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires root or function to be present"))
         }
 
         guard let kind = aKind else {

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -10,7 +10,7 @@ import XMLCoder
 @testable import MusicXML
 
 class MetronomeTests: XCTestCase {
-    func testDecodingMetronome_regular() throws {
+    func testDecodingMetronome_perMinute() throws {
         let xml = """
         <metronome parentheses="no" default-x="-25.96" relative-y="20.00">
           <beat-unit>quarter</beat-unit>
@@ -28,6 +28,76 @@ class MetronomeTests: XCTestCase {
                     relation: .perMinute(
                         PerMinute(value: "90")
                     )
+                )
+            )
+        )
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testDecodingMetronome_perMinute_withDot() throws {
+        let xml = """
+        <metronome parentheses="yes">
+          <beat-unit>quarter</beat-unit>
+          <beat-unit-dot/>
+          <per-minute>77</per-minute>
+        </metronome>
+        """
+
+        let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
+        let expected: Metronome = Metronome(
+            parentheses: true,
+            kind: .regular(
+                Metronome.Regular(
+                    beatUnit: .quarter,
+                    beatUnitDot: [Empty()],
+                    relation: .perMinute(
+                        PerMinute(value: "77")
+                    )
+                )
+            )
+        )
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testDecodingMetronome_beatUnit() throws {
+        let xml = """
+        <metronome>
+          <beat-unit>quarter</beat-unit>
+          <beat-unit-dot/>
+          <beat-unit>half</beat-unit>
+          <beat-unit-dot/>
+        </metronome>
+        """
+
+        let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
+        let expected: Metronome = Metronome(
+            kind: .regular(
+                Metronome.Regular(
+                    beatUnit: .quarter,
+                    beatUnitDot: [Empty()],
+                    relation: .beatUnit(.half, [Empty()])
+                )
+            )
+        )
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testDecodingMetronome_noBeatUnitInFirst() throws {
+        let xml = """
+        <metronome parentheses="yes">
+          <beat-unit>long</beat-unit>
+          <beat-unit>32nd</beat-unit>
+          <beat-unit-dot/>
+        </metronome>
+        """
+
+        let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
+        let expected: Metronome = Metronome(
+            parentheses: true,
+            kind: .regular(
+                Metronome.Regular(
+                    beatUnit: .long,
+                    relation: .beatUnit(.thirysecond, [Empty()])
                 )
             )
         )

--- a/Tests/MusicXMLTests/XCTestManifests.swift
+++ b/Tests/MusicXMLTests/XCTestManifests.swift
@@ -168,7 +168,10 @@ extension MetronomeTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__MetronomeTests = [
-        ("testDecodingMetronome_regular", testDecodingMetronome_regular),
+        ("testDecodingMetronome_beatUnit", testDecodingMetronome_beatUnit),
+        ("testDecodingMetronome_noBeatUnitInFirst", testDecodingMetronome_noBeatUnitInFirst),
+        ("testDecodingMetronome_perMinute_withDot", testDecodingMetronome_perMinute_withDot),
+        ("testDecodingMetronome_perMinute", testDecodingMetronome_perMinute),
     ]
 }
 


### PR DESCRIPTION
…eparately

Some `Metronome` may be structured like
```xml
<metronome>
    <beat-unit>quarter</beat-unit>
    <beat-unit-dot/>
    <beat-unit-dot/>
    <beat-unit>half</beat-unit>
    <beat-unit-dot/>
    <beat-unit-dot/>
</metronome>
```
where the first group of `beat-unit` and `beat-unit-dot` belong to the left side and the second group belong to the right side of the equivalence relationship.

Keyed Decoder by default is unordered and will attempt to treat them as the same array.