### PR TITLE
Remove @testable from tests

### DIFF
--- a/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class AccidentalTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/AccordionRegistrationTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AccordionRegistrationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class AccordionRegistrationTests: XCTestCase {
     func testDecoding() throws {

--- a/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AttributesTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class AttributesTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/BackupTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/BackupTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class BackupTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/BarlineTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/BarlineTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class BarlineTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/ClefTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ClefTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class ClefTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/CreatorTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/CreatorTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class CreatorTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class DirectionTests: XCTestCase {
     func testDecodingDirection_metronome() throws {

--- a/Tests/MusicXMLTests/Complex Types/HarmonyTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/HarmonyTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class HarmonyTests: XCTestCase {
     func testDecoding_inversion() throws {

--- a/Tests/MusicXMLTests/Complex Types/IdentificationTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/IdentificationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class IdentificationTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/MIDIDeviceTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MIDIDeviceTests.swift
@@ -9,7 +9,7 @@ import Foundation
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MIDIDeviceTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MIDIInstrumentTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MeasureStyleTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MetronomeTests: XCTestCase {
     func testDecodingMetronome_perMinute() throws {

--- a/Tests/MusicXMLTests/Complex Types/MiscellaneousTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MiscellaneousTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MiscellaneousTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/MusicDataTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MusicDataTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class MusicDataTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class NotationsTests: XCTestCase {
     func testTied() throws {

--- a/Tests/MusicXMLTests/Complex Types/OrnamentsTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/OrnamentsTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class OrnamentsTests: XCTestCase {
     func testDecoding() throws {

--- a/Tests/MusicXMLTests/Complex Types/PartListTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartListTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PartListTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PartNameTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PartwiseMeasureTests: XCTestCase {
 
@@ -49,7 +49,7 @@ class PartwiseMeasureTests: XCTestCase {
             .decode(Partwise.Measure.self, from: xml.data(using: .utf8)!)
         let expected = Partwise.Measure(
             number: "1",
-            width: Tenths(value: 123.4),
+            width: 123.4,
             musicData: [
                 .attributes(
                     Attributes(

--- a/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PartwisePartTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/PitchTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PitchTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PitchTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/PitchUnpitchedRestTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PitchUnpitchedRestTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class PitchUnpitchedRestTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/RestTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/RestTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class RestTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class ScoreInstrumentTests: XCTestCase {
     func testDecoding() throws {

--- a/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class ScorePartTests: XCTestCase {
     // Adopted from MuseScore export

--- a/Tests/MusicXMLTests/Complex Types/TimeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/TimeTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 import XMLCoder
-@testable import MusicXML
+import MusicXML
 
 class TimeTests: XCTestCase {
 

--- a/Tests/MusicXMLTests/HelloWorld.swift
+++ b/Tests/MusicXMLTests/HelloWorld.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import MusicXML
+import MusicXML
 
 class HelloWorld: XCTestCase {
 

--- a/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
@@ -24,8 +24,11 @@ class LilyPondTests: XCTestCase {
             try sanitizedSources.forEach { source in
                 let sourceURL = sourceDir.appendingPathComponent(source)
                 do {
+                    let start = now()
                     let parsed = try MusicXML(url: sourceURL)
-                    publishSuccessfulParsing(for: "\(traversal)/\(source)")
+                    let duration = now() - start
+
+                    publishSuccessfulParsing(for: "\(traversal)/\(source)", in: duration)
                     let resultFileURL = resultsDir.appendingPathComponent("\(source).parsed")
                     try! String(describing: parsed).write(
                         to: resultFileURL,
@@ -62,8 +65,8 @@ class LilyPondTests: XCTestCase {
         print("❌ \(fileName)")
     }
 
-    func publishSuccessfulParsing(for fileName: String) {
-        print("✅ \(fileName)")
+    func publishSuccessfulParsing(for fileName: String, in secondsElapsed: Double) {
+        print("✅ \(secondsElapsed.formatted(decimalPlaces: 3))s \(fileName)")
     }
 
     func publishResultsDirectoryLocation(_ url: URL) {
@@ -100,4 +103,16 @@ private var testSuiteURL: URL {
         .deletingLastPathComponent() // => MusicXML/Tests/LilyPondTests
         .deletingLastPathComponent() // => MusicXML/Tests
         .appendingPathComponent("LilyPondTestSuite", isDirectory: true)
+}
+
+// MARK: - Benchmarking
+
+private func now() -> Double {
+    return Double(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
+}
+
+extension Double {
+    func formatted(decimalPlaces: Int) -> String {
+        return String(format: "%.\(decimalPlaces)f", self)
+    }
 }

--- a/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
@@ -23,13 +23,18 @@ class LilyPondTests: XCTestCase {
                 .sorted()
             try sanitizedSources.forEach { source in
                 let sourceURL = sourceDir.appendingPathComponent(source)
-                let parsed = try MusicXML(url: sourceURL)
-                let resultFileURL = resultsDir.appendingPathComponent("\(source).parsed")
-                try! String(describing: parsed).write(
-                    to: resultFileURL,
-                    atomically: true,
-                    encoding: .utf8
-                )
+                do {
+                    let parsed = try MusicXML(url: sourceURL)
+                    let resultFileURL = resultsDir.appendingPathComponent("\(source).parsed")
+                    try! String(describing: parsed).write(
+                        to: resultFileURL,
+                        atomically: true,
+                        encoding: .utf8
+                    )
+                } catch {
+                    print("- Unable to parse \(traversal)/\(source)")
+                    throw error
+                }
             }
         }
     }

--- a/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
@@ -10,95 +10,80 @@ import MusicXML
 
 class LilyPondTests: XCTestCase {
 
-    // All of the LilyPond tests which we will _not_ test, either because they require a breaking of
-    // the specification, or for some other good reason.
-    private let blacklist = [
-        // This test requires our model to break the spec.
-        "41g-PartNoId.xml",
-        // I don't think this is our job (at least at this point in time)
-        "90a-Compressed-MusicXML.mxl",
-    ]
-
     func testAll() throws {
-        // Create temporary directory for successfully parsed scores from the LilyPond test suite
-        let tempDirUrl = URL(fileURLWithPath: NSTemporaryDirectory())
+        let rootDir = try! prepareResultsDirectory()
+        publishResultsDirectoryLocation(rootDir)
+        for traversal in ["Partwise", "Timewise"] {
+            let resultsDir = try prepareResultsDirectoryForTraversal(traversal, in: rootDir)
+            let sourceDir = testSuiteURL.appendingPathComponent(traversal, isDirectory: true)
+            let sources = try FileManager.default.contentsOfDirectory(atPath: sourceDir.path)
+            let sanitizedSources = sources.lazy
+                .filter { $0.hasSuffix("xml") }
+                .filter { !blacklist.contains($0) }
+                .sorted()
+            try sanitizedSources.forEach { source in
+                let sourceURL = sourceDir.appendingPathComponent(source)
+                let parsed = try MusicXML(url: sourceURL)
+                let resultFileURL = resultsDir.appendingPathComponent("\(source).parsed")
+                try! String(describing: parsed).write(
+                    to: resultFileURL,
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+        }
+    }
+
+    /// Creates a directory for storing successfully parsed MusicXML files for a given traversal
+    /// (either "Partwise" or "Timewise").
+    func prepareResultsDirectoryForTraversal(_ traversal: String, in directory: URL) throws -> URL {
+        let url = directory.appendingPathComponent(traversal)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    /// Creates a temporary directory for storing successfully parsed MusicXML files.
+    ///
+    /// - Returns: The `URL` of the created directory.
+    func prepareResultsDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("LilyPondTestsResults")
-        try FileManager.default.createDirectory(
-            at: tempDirUrl,
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func publishResultsDirectoryLocation(_ url: URL) {
         print(
             """
-            Created LilyPondTest result directory at \(tempDirUrl.absoluteString).
+            Created LilyPondTest result directory at:
+
+                \(url.absoluteString)
+
             Parsed scores from LilyPond test suite will be written there for inspection.
             """
         )
-        // Collect successes and failures for logging
-        var successes: [String] = []
-        var failures: [(name: String, error: Error)] = []
-        for subdir in ["Partwise", "Timewise"] {
-            try FileManager.default.createDirectory(
-                at: tempDirUrl,
-                withIntermediateDirectories: true,
-                attributes: nil
-            )
-            let directory = testSuiteURL.appendingPathComponent(subdir, isDirectory: true)
-            try FileManager.default
-                .contentsOfDirectory(atPath: directory.path)
-                .sorted()
-                .filter { !blacklist.contains($0) }
-                .forEach { fileName in
-                    let fileURL = directory.appendingPathComponent(fileName)
-                    do {
-                        let parsed = try MusicXML(url: fileURL)
-                        let parsedResultDirUrl = tempDirUrl.appendingPathComponent(subdir)
-                        try FileManager.default.createDirectory(
-                            at: parsedResultDirUrl,
-                            withIntermediateDirectories: true
-                        )
-                        let parsedResultFileUrl = parsedResultDirUrl
-                            .appendingPathComponent("\(fileName).parsed")
-                        do {
-                            try String(describing: parsed).write(
-                                to: parsedResultFileUrl,
-                                atomically: true,
-                                encoding: .utf8
-                            )
-                        } catch {
-                            print("Failed to write result for \(fileName)")
-                        }
-                        successes.append("\(subdir)/\(fileName)")
-                    } catch {
-                        failures.append((name: "\(subdir)/\(fileName)", error: error))
-                    }
-                }
-        }
-        print()
-        print("# Successfully parsed \(successes.count) files:")
-        successes.forEach { print("- \($0)") }
-        print()
-        print("# Failed to parse \(failures.count) files:")
-        failures.forEach { name, error in
-            print("- \(name)")
-            print("  error: \(error))")
-        }
     }
 }
 
-extension LilyPondTests {
+// All of the LilyPond tests which we will _not_ test, either because they require a breaking of
+// the specification, or for some other good reason.
+private let blacklist = [
+    // This test requires our model to break the spec.
+    "41g-PartNoId.xml",
+    // I don't think this is our job (at least at this point in time)
+    "90a-Compressed-MusicXML.mxl",
+]
 
-    // The `URL` of the `LilyPondTestSuite` directory which contains two subdirectories:
-    //
-    //  - `Partwise`
-    //  - `Timewise`
-    //
-    // Each of these subdirectories contains all of the test music xml files for a given traversal.
-    var testSuiteURL: URL {
-        return URL(fileURLWithPath: "\(#file)")
-            .deletingLastPathComponent() // => MusicXML/Tests/MusicXMLTests/LilyPondTests
-            .deletingLastPathComponent() // => MusicXML/Tests/LilyPondTests
-            .deletingLastPathComponent() // => MusicXML/Tests
-            .appendingPathComponent("LilyPondTestSuite", isDirectory: true)
-    }
+// The `URL` of the `LilyPondTestSuite` directory which contains two subdirectories:
+//
+//  - `Partwise`
+//  - `Timewise`
+//
+// Each of these subdirectories contains all of the test music xml files for a given traversal.
+private var testSuiteURL: URL {
+    return URL(fileURLWithPath: "\(#file)")
+        .deletingLastPathComponent() // => MusicXML/Tests/MusicXMLTests/LilyPondTests
+        .deletingLastPathComponent() // => MusicXML/Tests/LilyPondTests
+        .deletingLastPathComponent() // => MusicXML/Tests
+        .appendingPathComponent("LilyPondTestSuite", isDirectory: true)
 }

--- a/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/LilyPondTestSuite.swift
@@ -25,6 +25,7 @@ class LilyPondTests: XCTestCase {
                 let sourceURL = sourceDir.appendingPathComponent(source)
                 do {
                     let parsed = try MusicXML(url: sourceURL)
+                    publishSuccessfulParsing(for: "\(traversal)/\(source)")
                     let resultFileURL = resultsDir.appendingPathComponent("\(source).parsed")
                     try! String(describing: parsed).write(
                         to: resultFileURL,
@@ -32,7 +33,7 @@ class LilyPondTests: XCTestCase {
                         encoding: .utf8
                     )
                 } catch {
-                    print("- Unable to parse \(traversal)/\(source)")
+                    publishFailedParsing(for: "\(traversal)/\(source)")
                     throw error
                 }
             }
@@ -55,6 +56,14 @@ class LilyPondTests: XCTestCase {
             .appendingPathComponent("LilyPondTestsResults")
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    func publishFailedParsing(for fileName: String) {
+        print("❌ \(fileName)")
+    }
+
+    func publishSuccessfulParsing(for fileName: String) {
+        print("✅ \(fileName)")
     }
 
     func publishResultsDirectoryLocation(_ url: URL) {


### PR DESCRIPTION
This PR removes all instances of @testable from our tests. This is a good measure of the state of our public API, and it also allows us to run tests in `release` mode.

In an upcoming PR, I may update Travis to run tests in release mode (which improves parsing speed by a pretty consistent 2x).