### PR TITLE
Convert #warning TODOs and FIXMEs to comments

### DIFF
--- a/Sources/MusicXML/Complex Types/Credit.swift
+++ b/Sources/MusicXML/Complex Types/Credit.swift
@@ -61,7 +61,7 @@ extension Credit {
         }
     }
 
-    
+    // FIXME: Establish correct model for Credit.Kind.words
     public enum Kind {
         case image(Image)
         case words([Words])

--- a/Sources/MusicXML/Complex Types/Credit.swift
+++ b/Sources/MusicXML/Complex Types/Credit.swift
@@ -61,7 +61,7 @@ extension Credit {
         }
     }
 
-    #warning("FIXME: Establish correct model for Credit.Kind.words")
+    
     public enum Kind {
         case image(Image)
         case words([Words])

--- a/Sources/MusicXML/Complex Types/DirectionType.swift
+++ b/Sources/MusicXML/Complex Types/DirectionType.swift
@@ -22,7 +22,8 @@ public enum DirectionType {
     case bracket(Bracket)
     /// The coda element is the visual indicator of a coda sign. A sound element is needed to guide
     /// playback applications reliably.
-    #warning("FIXME: #130 This should be `[EmptyPrintStyleAlign]`")
+
+    // FIXME: #130 This should be `[EmptyPrintStyleAlign]`
     case coda(EmptyPrintStyleAlign)
     /// The damp element specifies a harp damping mark.
     case damp(EmptyPrintStyleAlign)
@@ -44,7 +45,8 @@ public enum DirectionType {
     /// captures what is in the score, but does not try to be optimal for analysis or synthesis of
     /// dynamics.
     ///
-    #warning("FIXME: #130 This should be `[Dynamics]`")
+
+    // FIXME: #130 This should be `[Dynamics]`
     case dynamics(Dynamics)
     /// The eyeglasses element specifies the eyeglasses symbol, common in commercial music.
     case eyeglasses(EmptyPrintStyleAlign)
@@ -88,7 +90,8 @@ public enum DirectionType {
     case principleVoice(PrincipleVoice)
     /// The rehearsal type specifies a rehearsal mark. Language is Italian ("it") by default.
     /// Enclosure is square by default. Left justification is assumed if not specified.
-    #warning("FIXME: #130 This should be `[FormattedText]`")
+    
+    // FIXME: #130 This should be `[FormattedText]`
     case rehearsal(FormattedText)
     /// Scordatura string tunings are represented by a series of accord elements, similar to the
     /// staff-tuning elements. Strings are numbered from high to low.

--- a/Sources/MusicXML/Complex Types/Font.swift
+++ b/Sources/MusicXML/Complex Types/Font.swift
@@ -21,7 +21,7 @@ public struct Font {
 
     // MARK: - Attributes
 
-    #warning("Font.family should be `CommaSeparatedText`")
+    // FIXME: Font.family should be `CommaSeparatedText`
     public let family: String?
 
     public let style: FontStyle?

--- a/Sources/MusicXML/Complex Types/Lyric.swift
+++ b/Sources/MusicXML/Complex Types/Lyric.swift
@@ -85,7 +85,7 @@ public struct Lyric {
 
 extension Lyric {
 
-    #warning("TODO: Verify Content Model of Lyric.Verbal")
+    // TODO: Verify Content Model of Lyric.Verbal
     public struct Verbal {
         public let text: TextElementData
         public let syllabic: Syllabic?

--- a/Sources/MusicXML/Complex Types/MeasureStyle.swift
+++ b/Sources/MusicXML/Complex Types/MeasureStyle.swift
@@ -96,13 +96,12 @@ extension MeasureStyle: Codable {
     }
     public init(from decoder: Decoder) throws {
         // Decode attributes
-        #warning("TODO: Add MeasureStyle attributes decoding")
+        // TODO: Add MeasureStyle attributes decoding
         // Decode kind
         let kindContainer = try decoder.singleValueContainer()
         self.kind = try kindContainer.decode(Kind.self)
     }
     public func encode(to encoder: Encoder) throws {
-        #warning("TODO: MeasureStyle.encode(to:)")
-        fatalError()
+        fatalError("TODO: MeasureStyle.encode(to:)")
     }
 }

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -89,7 +89,7 @@ extension Metronome {
         }
     }
 
-    #warning("TODO: Consider renaming Metronome.Complicated")
+    // TODO: Consider renaming Metronome.Complicated
     public struct Complicated {
         public let metronomeNote: [MetronomeNote] // NonEmpty
         public let metronomeRelation: String

--- a/Sources/MusicXML/Complex Types/Opus.swift
+++ b/Sources/MusicXML/Complex Types/Opus.swift
@@ -7,7 +7,7 @@
 
 /// The opus type represents a link to a MusicXML opus document that composes multiple MusicXML
 /// scores into a collection.
-#warning("TODO: Flesh out Opus")
+// TODO: Flesh out Opus
 public struct Opus {
 
 

--- a/Sources/MusicXML/Complex Types/PageLayout.swift
+++ b/Sources/MusicXML/Complex Types/PageLayout.swift
@@ -31,7 +31,7 @@ extension PageLayout {
         }
     }
 
-    #warning("FIXME: Refactor Margins a little better to encode logic")
+    // FIXME: Refactor Margins a little better to encode logic
     public struct Margins: Codable, Equatable {
         let even: PageMargins
         let odd: PageMargins?

--- a/Sources/MusicXML/Complex Types/Score.swift
+++ b/Sources/MusicXML/Complex Types/Score.swift
@@ -33,7 +33,7 @@
 // <!ATTLIST score-partwise
 //    %document-attributes;
 // >
-#warning("TODO: Support Score document-attributes")
+// TODO: Support Score document-attributes
 public struct Score {
     public let traversal: Traversal
 

--- a/Sources/MusicXML/Complex Types/ScorePart.swift
+++ b/Sources/MusicXML/Complex Types/ScorePart.swift
@@ -11,7 +11,7 @@ import XMLCoder
 /// elements are used when there are multiple instruments per track. The midi-device element is used
 /// to make a MIDI device or port assignment for the given track or specific MIDI instruments.
 /// Initial midi-instrument assignments may be made here as well.
-#warning("TODO: Add support for ScorePart print-style, print-object, and justify")
+// TODO: Add support for ScorePart print-style, print-object, and justify
 public struct ScorePart {
 
     // MARK: - Attributes

--- a/Sources/MusicXML/Complex Types/Time.swift
+++ b/Sources/MusicXML/Complex Types/Time.swift
@@ -139,7 +139,7 @@ extension Time {
     // > available compared to the time element's symbol attribute,
     // > which applies to the first of the dual time signatures.
     public struct Measured {
-        #warning("Handle multiple time signatures in Time.Measured")
+        // FIXME: Handle multiple time signatures in Time.Measured
         var signature: Signature
         var interchangeable: Interchangeable?
 
@@ -239,7 +239,7 @@ extension Time: Codable {
         self.printObject = try container.decodeIfPresent(Bool.self, forKey: .printObject)
         // Decode kind
         do {
-            #warning("Audit containers in Time.init(from: Decoder)")
+            // FIXME: Audit containers in Time.init(from: Decoder)
             let kindContainer = try decoder.container(keyedBy: Measured.CodingKeys.self)
             let signatureContainer = try decoder.container(keyedBy: Signature.CodingKeys.self)
             self.kind = .measured(

--- a/Sources/MusicXML/Simple Types/Fifths.swift
+++ b/Sources/MusicXML/Simple Types/Fifths.swift
@@ -5,4 +5,4 @@
 //  Created by James Bean on 5/14/19.
 //
 
-#warning("TODO: Audit whether Fifths should be its own type, or if `Int` is fine.")
+// FIXME: Audit whether Fifths should be its own type, or if `Int` is fine.

--- a/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
@@ -1383,7 +1383,7 @@ class PartwisePartTests: XCTestCase {
           </measure>
         </part>
         """
-        let decoded = try XMLDecoder().decode(Partwise.Part.self, from: xml.data(using: .utf8)!)
-        #warning("Add assertion to PatwisePartTests.testDecoding()")
+        let _ = try XMLDecoder().decode(Partwise.Part.self, from: xml.data(using: .utf8)!)
+        // FIXME: Add assertion to PatwisePartTests.testDecoding()
     }
 }


### PR DESCRIPTION
This PR converts the current methodology of using `#warning`s to using `//` (comments).

While the `#warning`s are convenient during development, they leak out to users of the library. We can still search for them as we need to.