### PR TITLE
Streamline some naming and initializers

### DIFF
--- a/Sources/MusicXML/Complex Types/AccordionRegistration.swift
+++ b/Sources/MusicXML/Complex Types/AccordionRegistration.swift
@@ -11,25 +11,40 @@
 /// presence of one or more dots in the registration diagram. An accordion-registration element
 /// needs to have at least one of the child elements present.
 public struct AccordionRegistration {
-    public let printStyleAlign: PrintStyleAlign
-    public let accordionHigh: Empty?
-    public let accordionMiddle: AccordionMiddle?
-    public let accordionLow: Empty?
 
-    public init(printStyleAlign: PrintStyleAlign = PrintStyleAlign(), accordionHigh: Empty? = nil, accordionMiddle: AccordionMiddle? = nil, accordionLow: Empty? = nil) {
+    // MARK: - Instance Properties
+
+    // MARK: Attribute Groups
+
+    public let printStyleAlign: PrintStyleAlign
+
+    // MARK: Elements
+
+    public let high: Empty?
+    public let middle: AccordionMiddle?
+    public let low: Empty?
+
+    // MARK: - Initializers
+
+    public init(
+        printStyleAlign: PrintStyleAlign = PrintStyleAlign(),
+        accordionHigh: Empty? = nil,
+        accordionMiddle: AccordionMiddle? = nil,
+        accordionLow: Empty? = nil
+    ) {
         self.printStyleAlign = printStyleAlign
-        self.accordionHigh = accordionHigh
-        self.accordionMiddle = accordionMiddle
-        self.accordionLow = accordionLow
+        self.high = accordionHigh
+        self.middle = accordionMiddle
+        self.low = accordionLow
     }
 }
 
 extension AccordionRegistration: Equatable { }
 extension AccordionRegistration: Codable {
     private enum CodingKeys: String, CodingKey {
-        case accordionHigh = "accordion-high"
-        case accordionMiddle = "accordion-middle"
-        case accordionLow = "accordion-low"
+        case high = "accordion-high"
+        case middle = "accordion-middle"
+        case low = "accordion-low"
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -39,8 +54,8 @@ extension AccordionRegistration: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.printStyleAlign = try PrintStyleAlign(from: decoder)
-        self.accordionHigh = try container.decodeIfPresent(Empty.self, forKey: .accordionHigh)
-        self.accordionMiddle = try container.decodeIfPresent(AccordionMiddle.self, forKey: .accordionMiddle)
-        self.accordionLow = try container.decodeIfPresent(Empty.self, forKey: .accordionLow)
+        self.high = try container.decodeIfPresent(Empty.self, forKey: .high)
+        self.middle = try container.decodeIfPresent(AccordionMiddle.self, forKey: .middle)
+        self.low = try container.decodeIfPresent(Empty.self, forKey: .low)
     }
 }

--- a/Sources/MusicXML/Complex Types/Bass.swift
+++ b/Sources/MusicXML/Complex Types/Bass.swift
@@ -9,12 +9,12 @@
 /// generally not used in functional harmony, as inversion is generally not used in pop chord
 /// symbols. As with root, it is divided into step and alter elements, similar to pitches.
 public struct Bass {
-    public let bassStep: BassStep
-    public let bassAlter: BassAlter?
+    public let step: BassStep
+    public let alter: BassAlter?
 
-    public init(bassStep: BassStep, bassAlter: BassAlter? = nil) {
-        self.bassStep = bassStep
-        self.bassAlter = bassAlter
+    public init(step: BassStep, alter: BassAlter? = nil) {
+        self.step = step
+        self.alter = alter
     }
 }
 
@@ -22,7 +22,7 @@ extension Bass: Equatable {}
 
 extension Bass: Codable {
     private enum CodingKeys: String, CodingKey {
-        case bassStep = "bass-step"
-        case bassAlter = "bass-alter"
+        case step = "bass-step"
+        case alter = "bass-alter"
     }
 }

--- a/Sources/MusicXML/Complex Types/BassStep.swift
+++ b/Sources/MusicXML/Complex Types/BassStep.swift
@@ -16,11 +16,24 @@ public struct BassStep {
     public let text: String?
     public let printStyle: PrintStyle
 
-    public init(value: Step, text: String? = nil, printStyle: PrintStyle = PrintStyle()) {
+    public init(_ value: Step, text: String? = nil, printStyle: PrintStyle = PrintStyle()) {
         self.value = value
         self.text = text
         self.printStyle = printStyle
     }
+}
+
+extension BassStep {
+
+    // MARK: - Type Properties
+
+    public static let a = BassStep(.a)
+    public static let b = BassStep(.b)
+    public static let c = BassStep(.c)
+    public static let d = BassStep(.d)
+    public static let e = BassStep(.e)
+    public static let f = BassStep(.f)
+    public static let g = BassStep(.g)
 }
 
 extension BassStep: Equatable { }

--- a/Sources/MusicXML/Complex Types/Degree.swift
+++ b/Sources/MusicXML/Complex Types/Degree.swift
@@ -12,13 +12,30 @@
 /// harmony of kind "other" can be spelled explicitly by using a series of degree elements together
 /// with a root.
 public struct Degree {
-    public let printObject: Bool?
+
+    // MARK: - Instance Properties
+
+    // MARK: Value
 
     public let value: DegreeValue
+
+    // MARK: Attributes
+
+    public let printObject: Bool?
+
+    // MARK: Elements
+
     public let alter: DegreeAlter
     public let type: DegreeType
 
-    public init(printObject: Bool? = nil, value: DegreeValue, alter: DegreeAlter, type: DegreeType) {
+    // MARK: - Initializers
+
+    public init(
+        _ value: DegreeValue,
+        alter: DegreeAlter,
+        type: DegreeType,
+        printObject: Bool? = nil
+    ) {
         self.value = value
         self.alter = alter
         self.type = type

--- a/Sources/MusicXML/Complex Types/DegreeAlter.swift
+++ b/Sources/MusicXML/Complex Types/DegreeAlter.swift
@@ -12,11 +12,24 @@
 /// plus-minus attribute is used to indicate if plus and minus symbols should be used instead of
 /// sharp and flat symbols to display the degree alteration; it is no by default.
 public struct DegreeAlter {
+
+    // MARK: - Instance Properties
+
+    // MARK: Value
+
     public let value: Int
-    public let printStyle: PrintStyle
+
+    // MARK: Attributes
+
     public let plusMinus: Bool?
 
-    public init(value: Int, printStyle: PrintStyle = PrintStyle(), plusMinus: Bool? = nil) {
+    // MARK: Attribute Groups
+
+    public let printStyle: PrintStyle
+
+    // MARK: - Initializers
+
+    public init(_ value: Int, printStyle: PrintStyle = PrintStyle(), plusMinus: Bool? = nil) {
         self.value = value
         self.printStyle = printStyle
         self.plusMinus = plusMinus
@@ -35,5 +48,12 @@ extension DegreeAlter: Codable {
         self.printStyle = try PrintStyle(from: decoder)
         self.value = try container.decode(Int.self, forKey: .value)
         self.plusMinus = try container.decodeIfPresent(Bool.self, forKey: .plusMinus)
+    }
+}
+
+extension DegreeAlter: ExpressibleByIntegerLiteral {
+    // MARK: - ExpressibleByIntegerLiteral
+    public init(integerLiteral value: Int) {
+        self.init(value)
     }
 }

--- a/Sources/MusicXML/Complex Types/DegreeType.swift
+++ b/Sources/MusicXML/Complex Types/DegreeType.swift
@@ -10,15 +10,41 @@
 /// interpretation of the value of the degree-alter element. The text attribute specifies how the
 /// type of the degree should be displayed in a score.
 public struct DegreeType {
+
+    // MARK: - Instance Propertie
+
+    // MARK: Value
+
     let value: DegreeTypeValue
+
+    // MARK: Attributes
+
     let text: String?
+
+    // MARK: Attribute Groups
+
     let printStyle: PrintStyle
 
-    public init(value: DegreeTypeValue, text: String? = nil, printStyle: PrintStyle = PrintStyle()) {
+    // MARK: - Initializers
+
+    public init(
+        _ value: DegreeTypeValue,
+        text: String? = nil,
+        printStyle: PrintStyle = PrintStyle()
+    ) {
         self.value = value
         self.text = text
         self.printStyle = printStyle
     }
+}
+
+extension DegreeType {
+
+    // MARK: - Type Properties
+
+    public static let add = DegreeType(.add)
+    public static let alter = DegreeType(.alter)
+    public static let subtract = DegreeType(.subtract)
 }
 
 extension DegreeType: Equatable { }

--- a/Sources/MusicXML/Complex Types/DegreeValue.swift
+++ b/Sources/MusicXML/Complex Types/DegreeValue.swift
@@ -16,7 +16,12 @@ public struct DegreeValue {
     public let text: String?
     public let printStyle: PrintStyle
 
-    public init(value: Int, symbol: DegreeSymbolValue? = nil, text: String? = nil, printStyle: PrintStyle = PrintStyle()) {
+    public init(
+        _ value: Int,
+        symbol: DegreeSymbolValue? = nil,
+        text: String? = nil,
+        printStyle: PrintStyle = PrintStyle()
+    ) {
         self.value = value
         self.symbol = symbol
         self.text = text
@@ -38,5 +43,12 @@ extension DegreeValue: Codable {
         self.symbol = try container.decodeIfPresent(DegreeSymbolValue.self, forKey: .symbol)
         self.text = try container.decodeIfPresent(String.self, forKey: .text)
         self.printStyle = try PrintStyle(from: decoder)
+    }
+}
+
+extension DegreeValue: ExpressibleByIntegerLiteral {
+    // MARK: - ExpressibleByIntegerLiteral
+    public init(integerLiteral value: Int) {
+        self.init(value)
     }
 }

--- a/Sources/MusicXML/Complex Types/Inversion.swift
+++ b/Sources/MusicXML/Complex Types/Inversion.swift
@@ -8,10 +8,18 @@
 /// The inversion type represents harmony inversions. The value is a number indicating which
 /// inversion is used: 0 for root position, 1 for first inversion, etc.
 public struct Inversion {
+
+    // MARK: - Instance Properties
+
+    // MARK: Value
+
     public let value: Int
+
+    // MARK: Attribute Groups
+
     public let printStyle: PrintStyle
 
-    public init(value: Int, printStyle: PrintStyle = PrintStyle()) {
+    public init(_ value: Int, printStyle: PrintStyle = PrintStyle()) {
         self.value = value
         self.printStyle = printStyle
     }
@@ -32,6 +40,6 @@ extension Inversion: Codable {
 
 extension Inversion: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
-        self.init(value: value)
+        self.init(value)
     }
 }

--- a/Sources/MusicXML/Complex Types/Kind.swift
+++ b/Sources/MusicXML/Complex Types/Kind.swift
@@ -10,18 +10,39 @@
 /// make up a polychord, many formatting attributes are here. The alignment attributes are for the
 /// entire harmony-chord group of which this kind element is a part.
 public struct Kind {
+
+    // MARK: - Instance Properties
+
+    // MARK: Value
+
+    public let value: KindValue
+
+    // MARK: Attributes
+
     public let useSymbols: Bool?
     public let text: String?
     public let stackDegrees: Bool?
     public let parenthesesDegrees: Bool?
     public let bracketDegrees: Bool?
-    public let printStyle: PrintStyle
     public let hAlign: LeftCenterRight?
     public let vAlign: VAlign?
 
-    public let value: KindValue
+    // MARK: Attribute Groups
 
-    public init(useSymbols: Bool? = nil, text: String? = nil, stackDegrees: Bool? = nil, parenthesesDegrees: Bool? = nil, bracketDegrees: Bool? = nil, printStyle: PrintStyle = PrintStyle(), hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil, value: KindValue) {
+    public let printStyle: PrintStyle
+
+
+    public init(
+        _ value: KindValue,
+        useSymbols: Bool? = nil,
+        text: String? = nil,
+        stackDegrees: Bool? = nil,
+        parenthesesDegrees: Bool? = nil,
+        bracketDegrees: Bool? = nil,
+        printStyle: PrintStyle = PrintStyle(),
+        hAlign: LeftCenterRight? = nil,
+        vAlign: VAlign? = nil
+    ) {
         self.useSymbols = useSymbols
         self.text = text
         self.stackDegrees = stackDegrees
@@ -32,6 +53,45 @@ public struct Kind {
         self.vAlign = vAlign
         self.value = value
     }
+}
+
+extension Kind {
+
+    // MARK: - Type Properties
+
+    public static let major = Kind(.major)
+    public static let minor = Kind(.minor)
+    public static let augmented = Kind(.augmented)
+    public static let diminished = Kind(.diminished)
+    public static let dominant = Kind(.dominant)
+    public static let majorSeventh = Kind(.majorSeventh)
+    public static let minorSeventh = Kind(.minorSeventh)
+    public static let diminishedSeventh = Kind(.diminishedSeventh)
+    public static let augmentedSeventh = Kind(.augmentedSeventh)
+    public static let halfDiminished = Kind(.halfDiminished)
+    public static let majorMinor = Kind(.majorMinor)
+    public static let majorSixth = Kind(.majorSixth)
+    public static let minorSixth = Kind(.minorSixth)
+    public static let dominantNinth = Kind(.dominantNinth)
+    public static let majorNinth = Kind(.majorNinth)
+    public static let minorNinth = Kind(.minorNinth)
+    public static let dominantEleventh = Kind(.dominantEleventh)
+    public static let majorEleventh = Kind(.majorEleventh)
+    public static let minorEleventh = Kind(.minorEleventh)
+    public static let dominantThirteenth = Kind(.dominantThirteenth)
+    public static let majorThirteenth = Kind(.majorThirteenth)
+    public static let minorThirteenth = Kind(.minorThirteenth)
+    public static let suspendedSecond = Kind(.suspendedSecond)
+    public static let suspendedFourth = Kind(.suspendedFourth)
+    public static let neapolitan = Kind(.neapolitan)
+    public static let italian = Kind(.italian)
+    public static let french = Kind(.french)
+    public static let german = Kind(.german)
+    public static let pedalPointBass = Kind(.pedalPointBass)
+    public static let power = Kind(.power)
+    public static let tristan = Kind(.tristan)
+    public static let other = Kind(.other)
+    public static let none = Kind(.none)
 }
 
 extension Kind: Equatable {}

--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -51,21 +51,21 @@ public struct MIDIInstrument {
 
     public init(
         id: String,
-        midiChannel: Int? = nil,
-        midiName: String? = nil,
-        midiBank: Int? = nil,
-        midiProgram: Int? = nil,
-        midiUnpitched: Int? = nil,
+        channel: Int? = nil,
+        name: String? = nil,
+        bank: Int? = nil,
+        program: Int? = nil,
+        unpitched: Int? = nil,
         volume: Double? = nil,
         pan: Int? = nil,
         elevation: Int? = nil
     ) {
         self.id = id
-        self.channel = midiChannel
-        self.name = midiName
-        self.bank = midiBank
-        self.program = midiProgram
-        self.unpitched = midiUnpitched
+        self.channel = channel
+        self.name = name
+        self.bank = bank
+        self.program = program
+        self.unpitched = unpitched
         self.volume = volume
         self.pan = pan
         self.elevation = elevation

--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -13,18 +13,18 @@ import XMLCoder
 public struct MIDIInstrument {
     public var id: String
     /// The midi-channel element specifies a MIDI 1.0 channel number ranging from 1 to 16.
-    public var midiChannel: Int?
+    public var channel: Int?
     /// The midi-name element corresponds to a ProgramName meta-event within a Standard MIDI File.
-    public var midiName: String?
+    public var name: String?
     /// The midi-bank element specified a MIDI 1.0 bank number ranging from 1 to 16,384.
-    public var midiBank: Int?
+    public var bank: Int?
     /// The midi-program element specifies a MIDI 1.0 program number ranging from 1 to 128.
-    public var midiProgram: Int?
+    public var program: Int?
     /// For unpitched instruments, the midi-unpitched element specifies a MIDI 1.0 note number
     /// ranging from 1 to 128. It is usually used with MIDI banks for percussion. Note that MIDI 1.0
     /// note numbers are generally specified from 0 to 127 rather than the 1 to 128 numbering used
     /// in this element.
-    public var midiUnpitched: Int?
+    public var unpitched: Int?
     /// The volume element value is a percentage of the maximum ranging from 0 to 100, with decimal
     /// values allowed. This corresponds to a scaling value for the MIDI 1.0 channel volume
     /// controller.
@@ -39,13 +39,25 @@ public struct MIDIInstrument {
     /// with the listener, 90 is directly above, and -90 is directly below.
     public var elevation: Int?
 
-    public init(id: String, midiChannel: Int? = nil, midiName: String? = nil, midiBank: Int? = nil, midiProgram: Int? = nil, midiUnpitched: Int? = nil, volume: Double? = nil, pan: Int? = nil, elevation: Int? = nil) {
+    // MARK: - Initializers
+
+    public init(
+        id: String,
+        midiChannel: Int? = nil,
+        midiName: String? = nil,
+        midiBank: Int? = nil,
+        midiProgram: Int? = nil,
+        midiUnpitched: Int? = nil,
+        volume: Double? = nil,
+        pan: Int? = nil,
+        elevation: Int? = nil
+    ) {
         self.id = id
-        self.midiChannel = midiChannel
-        self.midiName = midiName
-        self.midiBank = midiBank
-        self.midiProgram = midiProgram
-        self.midiUnpitched = midiUnpitched
+        self.channel = midiChannel
+        self.name = midiName
+        self.bank = midiBank
+        self.program = midiProgram
+        self.unpitched = midiUnpitched
         self.volume = volume
         self.pan = pan
         self.elevation = elevation
@@ -57,11 +69,11 @@ extension MIDIInstrument: Codable {
 
     enum CodingKeys: String, CodingKey {
         case id
-        case midiChannel = "midi-channel"
-        case midiName = "midi-name"
-        case midiBank = "midi-bank"
-        case midiProgram = "midi-program"
-        case midiUnpitched = "midi-unpitched"
+        case channel = "midi-channel"
+        case name = "midi-name"
+        case bank = "midi-bank"
+        case program = "midi-program"
+        case unpitched = "midi-unpitched"
         case volume
         case pan
         case elevation

--- a/Sources/MusicXML/Complex Types/MIDIInstrument.swift
+++ b/Sources/MusicXML/Complex Types/MIDIInstrument.swift
@@ -11,7 +11,15 @@ import XMLCoder
 /// be a part of either the score-instrument element at the start of a part, or the sound element
 /// within a part. The id attribute refers to the score-instrument affected by the change.
 public struct MIDIInstrument {
+
+    // MARK: - Instance Properties
+
+    // MARK: Attributes
+
     public var id: String
+
+    // MARK: Elements
+
     /// The midi-channel element specifies a MIDI 1.0 channel number ranging from 1 to 16.
     public var channel: Int?
     /// The midi-name element corresponds to a ProgramName meta-event within a Standard MIDI File.

--- a/Sources/MusicXML/Complex Types/PartName.swift
+++ b/Sources/MusicXML/Complex Types/PartName.swift
@@ -9,12 +9,30 @@
 /// attributes for the part-name element are deprecated in Version 2.0 in favor of the new
 /// part-name-display and part-abbreviation-display elements.
 public struct PartName {
+
+    // MARK: - Instance Properties
+
+    // MARK: Value
+
     public var value: String
-    public var printStyle: PrintStyle
+
+    // MARK: - Attributes
+
     public var printObject: Bool?
     public var justify: Justify?
 
-    public init(value: String, printStyle: PrintStyle = PrintStyle(), printObject: Bool? = nil, justify: Justify? = nil) {
+    // MARK: - Attribute Groups
+
+    public var printStyle: PrintStyle
+
+    // MARK: - Initializers
+
+    public init(
+        _ value: String,
+        printStyle: PrintStyle = PrintStyle(),
+        printObject: Bool? = nil,
+        justify: Justify? = nil
+    ) {
         self.value = value
         self.printStyle = printStyle
         self.printObject = printObject
@@ -40,7 +58,10 @@ extension PartName: Codable {
 }
 
 extension PartName: ExpressibleByStringLiteral {
+
+    // MARK: - ExpressibleByStringLiteral
+
     public init(stringLiteral value: String) {
-        self.init(value: value)
+        self.init(value)
     }
 }

--- a/Sources/MusicXML/Complex Types/RootAlter.swift
+++ b/Sources/MusicXML/Complex Types/RootAlter.swift
@@ -10,13 +10,30 @@
 /// root-alter information. In that case, the print-object attribute of the root-alter element can
 /// be set to no.
 public struct RootAlter {
+
+    // MARK: - Instance Propertes
+
+    // MARK: Value
+
     public let value: Double
+
+    // MARK: Attributes
+
     public let printObject: Bool?
-    public let printStyle: PrintStyle
     public let location: LeftRight?
 
+    // MARK: Attribute Groups
 
-    public init(value: Double, printObject: Bool? = nil, printStyle: PrintStyle = PrintStyle(), location: LeftRight? = nil) {
+    public let printStyle: PrintStyle
+
+    // MARK: - Initializers
+
+    public init(
+        _ value: Double,
+        printObject: Bool? = nil,
+        printStyle: PrintStyle = PrintStyle(),
+        location: LeftRight? = nil
+    ) {
         self.value = value
         self.printObject = printObject
         self.printStyle = printStyle
@@ -43,6 +60,12 @@ extension RootAlter: Codable {
 
 extension RootAlter: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Double) {
-        self.init(value: value)
+        self.init(value)
+    }
+}
+
+extension RootAlter: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self.init(Double(value))
     }
 }

--- a/Sources/MusicXML/Complex Types/RootStep.swift
+++ b/Sources/MusicXML/Complex Types/RootStep.swift
@@ -12,11 +12,28 @@ public struct RootStep {
     public let text: String?
     public let printStyle: PrintStyle
 
-    public init(value: Step, text: String? = nil, printStyle: PrintStyle = PrintStyle()) {
+    public init(
+        _ value: Step,
+        text: String? = nil,
+        printStyle: PrintStyle = PrintStyle()
+    ) {
         self.value = value
         self.text = text
         self.printStyle = printStyle
     }
+}
+
+extension RootStep {
+
+    // MARK: - Type Properties
+
+    public static let a = RootStep(.a)
+    public static let b = RootStep(.b)
+    public static let c = RootStep(.c)
+    public static let d = RootStep(.d)
+    public static let e = RootStep(.e)
+    public static let f = RootStep(.f)
+    public static let g = RootStep(.g)
 }
 
 extension RootStep: Equatable { }

--- a/Sources/MusicXML/Complex Types/ScoreInstrument.swift
+++ b/Sources/MusicXML/Complex Types/ScoreInstrument.swift
@@ -15,17 +15,34 @@ import XMLCoder
 /// without these elements in simple cases, such as where part names match General MIDI instrument
 /// names.
 public struct ScoreInstrument {
+
+    // MARK: - Instance Properties
+
+    // MARK: Attributes
+
     public var id: String
-    public var instrumentName: String
-    public var instrumentAbbreviation: String?
+
+    // MARK: Elements
+
+    public var name: String
+    public var abbreviation: String?
     public var sound: String?
     public var soloOrEnsemble: SoloEnsemble?
     public var virtualInstrument: VirtualInstrument?
 
-    public init(id: String, instrumentName: String, instrumentAbbreviation: String? = nil, sound: String? = nil, soloOrEnsemble: SoloEnsemble? = nil, virtualInstrument: VirtualInstrument? = nil) {
+    // MARK: Initializers
+
+    public init(
+        id: String,
+        name: String,
+        abbreviation: String? = nil,
+        sound: String? = nil,
+        soloOrEnsemble: SoloEnsemble? = nil,
+        virtualInstrument: VirtualInstrument? = nil
+    ) {
         self.id = id
-        self.instrumentName = instrumentName
-        self.instrumentAbbreviation = instrumentAbbreviation
+        self.name = name
+        self.abbreviation = abbreviation
         self.sound = sound
         self.soloOrEnsemble = soloOrEnsemble
         self.virtualInstrument = virtualInstrument
@@ -56,11 +73,19 @@ extension ScoreInstrument.SoloEnsemble: Codable {
         }
     }
     public init(from decoder: Decoder) throws {
-        let keyed = try decoder.container(keyedBy: CodingKeys.self)
-        do {
-            self = .ensemble(try keyed.decode(String.self, forKey: .ensemble))
-        } catch {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.ensemble) {
+            self = .ensemble(try container.decode(String.self, forKey: .ensemble))
+        } else if container.contains(.solo) {
             self = .solo
+        } else {
+            throw DecodingError.typeMismatch(
+                ScoreInstrument.SoloEnsemble.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unrecognized ScoreInstrument.SoloEnsemble"
+                )
+            )
         }
     }
 }
@@ -69,8 +94,8 @@ extension ScoreInstrument: Equatable { }
 extension ScoreInstrument: Codable {
     enum CodingKeys: String, CodingKey {
         case id
-        case instrumentName = "instrument-name"
-        case instrumentAbbreviation = "instrument-abbreviation"
+        case name = "instrument-name"
+        case abbreviation = "instrument-abbreviation"
         case sound
         case soloOrEnsemble
         case virtualInstrument = "virtual-instrument"

--- a/Tests/MusicXMLTests/Complex Types/HarmonyTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/HarmonyTests.swift
@@ -25,14 +25,9 @@ class HarmonyTests: XCTestCase {
         let expected: Harmony = Harmony(
             chords: [
                 HarmonyChord(
-                    rootOrFunction: .root(
-                        Root(
-                            step: RootStep(value: .f),
-                            alter: RootAlter(value: 1)
-                        )
-                    ),
-                    kind: Kind(value: .major),
-                    inversion: Inversion(value: 2)
+                    rootOrFunction: .root(Root(step: .f, alter: 1)),
+                    kind: .major,
+                    inversion: 2
                 )
             ]
         )
@@ -77,41 +72,20 @@ class HarmonyTests: XCTestCase {
         let expected: Harmony = Harmony(
             chords: [
                 HarmonyChord(
-                    rootOrFunction: .root(
-                        Root(
-                            step: RootStep(value: .f),
-                            alter: RootAlter(value: 1)
-                        )
-                    ),
-                    kind: Kind(value: .major),
-                    inversion: Inversion(value: 2),
-                    bass: Bass(bassStep: BassStep(value: .d), bassAlter: 1.0),
+                    rootOrFunction: .root(Root(step: .f, alter: 1)),
+                    kind: .major,
+                    inversion: 2,
+                    bass: Bass(step: .d, alter: 1.0),
                     degrees: [
-                        Degree(
-                            value: DegreeValue(value: 6),
-                            alter: DegreeAlter(value: -1),
-                            type: DegreeType(value: .add)
-                        )
+                        Degree(6, alter: -1, type: .add)
                     ]
                 ),
                 HarmonyChord(
-                    rootOrFunction: .root(
-                        Root(
-                            step: RootStep(value: .c)
-                        )
-                    ),
-                    kind: Kind(value: .neapolitan),
+                    rootOrFunction: .root(Root(step: .c)),
+                    kind: Kind(.neapolitan),
                     degrees: [
-                        Degree(
-                            value: DegreeValue(value: 3),
-                            alter: DegreeAlter(value: 0),
-                            type: DegreeType(value: .subtract)
-                        ),
-                        Degree(
-                            value: DegreeValue(value: 5),
-                            alter: DegreeAlter(value: -1),
-                            type: DegreeType(value: .alter)
-                        )
+                        Degree(3, alter: 0, type: .subtract),
+                        Degree(5, alter: -1, type: .alter)
                     ]
                 )
             ]
@@ -148,34 +122,16 @@ class HarmonyTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Harmony.self, from: xml.data(using: .utf8)!)
         let expected: Harmony = Harmony(
-            printStyle: PrintStyle(
-                position: Position(defaultY: 40)
-            ),
+            printStyle: PrintStyle(position: Position(defaultY: 40)),
             chords: [
                 HarmonyChord(
-                    rootOrFunction: .root(
-                        Root(
-                            step: RootStep(value: .a)
-                        )
-                    ),
-                    kind: Kind(value: .minorSeventh),
-                    bass: Bass(bassStep: BassStep(value: .g)),
+                    rootOrFunction: .root(Root(step: .a)),
+                    kind: Kind(.minorSeventh),
+                    bass: Bass(step: .g),
                     degrees: [
-                        Degree(
-                            value: DegreeValue(value: 13),
-                            alter: DegreeAlter(value: 1),
-                            type: DegreeType(value: .add)
-                        ),
-                        Degree(
-                            value: DegreeValue(value: 3),
-                            alter: DegreeAlter(value: 0),
-                            type: DegreeType(value: .subtract)
-                        ),
-                        Degree(
-                            value: DegreeValue(value: 5),
-                            alter: DegreeAlter(value: -1),
-                            type: DegreeType(value: .alter)
-                        )
+                        Degree(13, alter: 1, type: .add),
+                        Degree(3, alter: 0, type: .subtract),
+                        Degree(5, alter: -1, type: .alter)
                     ]
                 )
             ]
@@ -192,11 +148,7 @@ class HarmonyTests: XCTestCase {
         </degree>
         """
         let decoded = try XMLDecoder().decode(Degree.self, from: xml.data(using: .utf8)!)
-        let expected: Degree = Degree(
-            value: DegreeValue(value: 13),
-            alter: DegreeAlter(value: -1),
-            type: DegreeType(value: .add)
-        )
+        let expected: Degree = Degree(13, alter: -1, type: .add)
         XCTAssertEqual(decoded, expected)
     }
 
@@ -209,9 +161,7 @@ class HarmonyTests: XCTestCase {
         </wrapper>
         """
         let decoded = try XMLDecoder().decode(HarmonyChord.RootOrFunction.self, from: xml.data(using: .utf8)!)
-        let expected: HarmonyChord.RootOrFunction = .root(
-            Root(step: RootStep(value: .a))
-        )
+        let expected: HarmonyChord.RootOrFunction = .root(Root(step: .a))
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
@@ -24,13 +24,13 @@ class MIDIInstrumentTests: XCTestCase {
         </midi-instrument>
         """
         let decoded = try XMLDecoder().decode(MIDIInstrument.self, from: xml.data(using: .utf8)!)
-        let expected = MIDIInstrument(id: "P1-I2", midiChannel: 1, midiProgram: 1, volume: 50, pan: -45)
+        let expected = MIDIInstrument(id: "P1-I2", channel: 1, program: 1, volume: 50, pan: -45)
 
         XCTAssertEqual(decoded, expected)
     }
 
     func testEncoding() throws {
-        let midiInstrument = MIDIInstrument(id: "P1-I1", midiChannel: 1, midiProgram: 1, volume: 78.7402, pan: 0)
+        let midiInstrument = MIDIInstrument(id: "P1-I1", channel: 1, program: 1, volume: 78.7402, pan: 0)
         let encoded = String(data: try XMLEncoder().encode(midiInstrument, withRootKey: "midi-instrument"), encoding: .utf8)!
 
         XCTAssertEqual(encoded, #"<midi-instrument id="P1-I1"><midi-channel>1</midi-channel><midi-program>1</midi-program><volume>78.7402</volume><pan>0</pan></midi-instrument>"#)

--- a/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MIDIInstrumentTests.swift
@@ -5,9 +5,6 @@
 //  Created by Ben Lu on 9/30/19.
 //
 
-
-import Foundation
-
 import XCTest
 import XMLCoder
 import MusicXML

--- a/Tests/MusicXMLTests/Complex Types/PartListTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartListTests.swift
@@ -20,9 +20,7 @@ class PartListTests: XCTestCase {
         </part-list>
         """
         let decoded = try XMLDecoder().decode(PartList.self, from: xml.data(using: .utf8)!)
-        let expected = PartList([
-            .part(ScorePart(id: "P1", name: PartName(value: "MusicXML Part")))
-        ])
+        let expected = PartList([.part(ScorePart(id: "P1", name: "MusicXML Part"))])
         XCTAssertEqual(decoded, expected)
     }
 
@@ -52,8 +50,8 @@ class PartListTests: XCTestCase {
                     barline: GroupBarline(value: .yes)
                 )
             ),
-            .part(ScorePart(id: "P1", name: PartName(value: "Part 1"))),
-            .part(ScorePart(id: "P2", name: PartName(value: "Part 2"))),
+            .part(ScorePart(id: "P1", name: "Part 1")),
+            .part(ScorePart(id: "P2", name: "Part 2")),
             .group(PartGroup(type: .stop, number: 1)),
         ])
         XCTAssertEqual(decoded, expected)

--- a/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
@@ -14,7 +14,7 @@ class PartNameTests: XCTestCase {
     func testDecoding() throws {
         let xml = "<part-name>MusicXML Part</part-name>"
         let decoded = try XMLDecoder().decode(PartName.self, from: xml.data(using: .utf8)!)
-        let expected = PartName(value: "MusicXML Part")
+        let expected = PartName("MusicXML Part")
         XCTAssertEqual(decoded, expected)
     }
 

--- a/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScoreInstrumentTests.swift
@@ -18,8 +18,7 @@ class ScoreInstrumentTests: XCTestCase {
         </score-instrument>
         """
         let decoded = try XMLDecoder().decode(ScoreInstrument.self, from: xml.data(using: .utf8)!)
-        let expected = ScoreInstrument(id: "P1-I1", instrumentName: "Piano")
-
+        let expected = ScoreInstrument(id: "P1-I1", name: "Piano")
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
@@ -58,8 +58,8 @@ class ScorePartTests: XCTestCase {
                     midiDevice: MIDIDevice(port: 1, id: "P1-I1"),
                     midiInstrument: MIDIInstrument(
                         id: "P1-I1",
-                        midiChannel: 1,
-                        midiProgram: 1,
+                        channel: 1,
+                        program: 1,
                         volume: 78.7402,
                         pan: 0
                     )
@@ -68,8 +68,8 @@ class ScorePartTests: XCTestCase {
                     midiDevice: MIDIDevice(port: 2, id: "P1-I2"),
                     midiInstrument: MIDIInstrument(
                         id: "P1-I2",
-                        midiChannel: 1,
-                        midiProgram: 1,
+                        channel: 1,
+                        program: 1,
                         volume: 50,
                         pan: -45
                     )

--- a/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
@@ -42,7 +42,7 @@ class ScorePartTests: XCTestCase {
         </score-part>
         """
         let decoded = try XMLDecoder().decode(ScorePart.self, from: xml.data(using: .utf8)!)
-        let expected = ScorePart(id: "P1", name: PartName(value: "MusicXML Part"))
+        let expected = ScorePart(id: "P1", name: "MusicXML Part")
         XCTAssertEqual(decoded, expected)
     }
 
@@ -50,12 +50,30 @@ class ScorePartTests: XCTestCase {
         let decoded = try XMLDecoder().decode(ScorePart.self, from: ScorePartTests.complexXml.data(using: .utf8)!)
         let expected = ScorePart(
             id: "P1",
-            name: PartName(value: "Piano"),
-            partAbbreviation: PartName(value: "Pno."),
+            name: "Piano",
+            partAbbreviation: "Pno.",
             scoreInstrument: [ScoreInstrument(id: "P1-I1", instrumentName: "Piano")],
             midi: [
-                ScorePart.MIDI(midiDevice: MIDIDevice(port: 1, id: "P1-I1"), midiInstrument: MIDIInstrument(id: "P1-I1", midiChannel: 1, midiProgram: 1, volume: 78.7402, pan: 0)),
-                ScorePart.MIDI(midiDevice: MIDIDevice(port: 2, id: "P1-I2"), midiInstrument: MIDIInstrument(id: "P1-I2", midiChannel: 1, midiProgram: 1, volume: 50, pan: -45))
+                ScorePart.MIDI(
+                    midiDevice: MIDIDevice(port: 1, id: "P1-I1"),
+                    midiInstrument: MIDIInstrument(
+                        id: "P1-I1",
+                        midiChannel: 1,
+                        midiProgram: 1,
+                        volume: 78.7402,
+                        pan: 0
+                    )
+                ),
+                ScorePart.MIDI(
+                    midiDevice: MIDIDevice(port: 2, id: "P1-I2"),
+                    midiInstrument: MIDIInstrument(
+                        id: "P1-I2",
+                        midiChannel: 1,
+                        midiProgram: 1,
+                        volume: 50,
+                        pan: -45
+                    )
+                )
             ]
         )
         XCTAssertEqual(decoded, expected)

--- a/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/ScorePartTests.swift
@@ -52,7 +52,7 @@ class ScorePartTests: XCTestCase {
             id: "P1",
             name: "Piano",
             partAbbreviation: "Pno.",
-            scoreInstrument: [ScoreInstrument(id: "P1-I1", instrumentName: "Piano")],
+            scoreInstrument: [ScoreInstrument(id: "P1-I1", name: "Piano")],
             midi: [
                 ScorePart.MIDI(
                     midiDevice: MIDIDevice(port: 1, id: "P1-I1"),

--- a/Tests/MusicXMLTests/HelloWorld.swift
+++ b/Tests/MusicXMLTests/HelloWorld.swift
@@ -57,14 +57,7 @@ class HelloWorld: XCTestCase {
                 traversal: .partwise(
                     Partwise(
                         header: Header(
-                            partList: PartList([
-                                .part(
-                                    ScorePart(
-                                        id: "P1",
-                                        name: PartName(value: "Music")
-                                    )
-                                )
-                            ])
+                            partList: PartList([.part(ScorePart(id: "P1", name: "Music"))])
                         ),
                         parts: [
                             Partwise.Part(

--- a/Tests/MusicXMLTests/LilyPondTests/PickupMeasureChordnamesFiguredBassTests.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/PickupMeasureChordnamesFiguredBassTests.swift
@@ -18,7 +18,7 @@ class PickupMeasureChordnamesFiguredBassTests: XCTestCase {
         </root>
         """
         let decoded = try XMLDecoder().decode(Root.self, from: xml.data(using: .utf8)!)
-        let expected = Root(step: RootStep(value: .c))
+        let expected = Root(step: .c)
         XCTAssertEqual(decoded, expected)
     }
 
@@ -36,8 +36,8 @@ class PickupMeasureChordnamesFiguredBassTests: XCTestCase {
             printFrame: false,
             chords: [
                 HarmonyChord(
-                    rootOrFunction: .root(Root(step: RootStep(value: .c))),
-                    kind: Kind(value: .major)
+                    rootOrFunction: .root(Root(step: .c)),
+                    kind: Kind(.major)
                 )
             ]
         )


### PR DESCRIPTION
This PR updates several names and initializers, as well as adds some `static let` forwards to underlying enum types for some types which are a bit clumsy to work with in the Swift source.

Highly source-breaking.