### PR TITLE
Improve Note initializer and various enhancements

### DIFF
--- a/Sources/MusicXML/Complex Types/Accidental.swift
+++ b/Sources/MusicXML/Complex Types/Accidental.swift
@@ -11,6 +11,12 @@
 /// attribute group.
 public struct Accidental {
 
+    // MARK: - Instance Properties
+
+    // MARK: Value
+
+    public let value: AccidentalValue
+
     // MARK: - Attributes
     
     public let cautionary: Bool?
@@ -18,23 +24,76 @@ public struct Accidental {
     public let parentheses: Bool?
     public let bracket: Bool?
     public let size: SymbolSize?
-    public let position: Position?
-    public let printStyle: PrintStyle?
 
-    // MARK: - Value
+    // MARK: Attribute Groups
 
-    public let value: AccidentalValue
+    public let printStyle: PrintStyle
 
-    public init(cautionary: Bool? = nil, editorial: Bool? = nil, parentheses: Bool? = nil, bracket: Bool? = nil, size: SymbolSize? = nil, position: Position? = nil, printStyle: PrintStyle? = nil, value: AccidentalValue) {
+    public init(
+        _ value: AccidentalValue,
+        cautionary: Bool? = nil,
+        editorial: Bool? = nil,
+        parentheses: Bool? = nil,
+        bracket: Bool? = nil,
+        size: SymbolSize? = nil,
+        printStyle: PrintStyle = PrintStyle()
+    ) {
+        self.value = value
         self.cautionary = cautionary
         self.editorial = editorial
         self.parentheses = parentheses
         self.bracket = bracket
         self.size = size
-        self.position = position
         self.printStyle = printStyle
-        self.value = value
     }
+}
+
+extension Accidental {
+
+    // MARK: - Type Properties
+
+    public static let sharp = Accidental(.sharp)
+    public static let natural = Accidental(.natural)
+    public static let flat = Accidental(.flat)
+    public static let doubleSharp = Accidental(.doubleSharp)
+    public static let sharpSharp = Accidental(.sharpSharp)
+    public static let flatFlat = Accidental(.flatFlat)
+    public static let doubleFlat = Accidental(.doubleFlat)
+    public static let naturalSharp = Accidental(.naturalSharp)
+    public static let naturalFlat = Accidental(.naturalFlat)
+    public static let quarterFlat = Accidental(.quarterFlat)
+    public static let quarterSharp = Accidental(.quarterSharp)
+    public static let threeQuartersFlat = Accidental(.threeQuartersFlat)
+    public static let threeQuartersSharp = Accidental(.threeQuartersSharp)
+    public static let sharpDown = Accidental(.sharpDown)
+    public static let sharpUp = Accidental(.sharpUp)
+    public static let naturalDown = Accidental(.naturalDown)
+    public static let naturalUp = Accidental(.naturalUp)
+    public static let flatDown = Accidental(.flatDown)
+    public static let flatUp = Accidental(.flatUp)
+    public static let doubleSharpDown = Accidental(.doubleSharpDown)
+    public static let doubleSharpUp = Accidental(.doubleSharpUp)
+    public static let flatFlatDown = Accidental(.flatFlatDown)
+    public static let flatFlatUp = Accidental(.flatFlatUp)
+    public static let arrowDown = Accidental(.arrowDown)
+    public static let arrowUp = Accidental(.arrowUp)
+    public static let tripleSharp = Accidental(.tripleSharp)
+    public static let tripleFlat = Accidental(.tripleFlat)
+    public static let slashQuarterSharp = Accidental(.slashQuarterSharp)
+    public static let slashSharp = Accidental(.slashSharp)
+    public static let slashFlat = Accidental(.slashFlat)
+    public static let doubleSlashFlat = Accidental(.doubleSlashFlat)
+    public static let sharp1 = Accidental(.sharp1)
+    public static let sharp2 = Accidental(.sharp2)
+    public static let sharp3 = Accidental(.sharp3)
+    public static let sharp5 = Accidental(.sharp5)
+    public static let flat1 = Accidental(.flat1)
+    public static let flat2 = Accidental(.flat2)
+    public static let flat3 = Accidental(.flat3)
+    public static let flat4 = Accidental(.flat4)
+    public static let sori = Accidental(.sori)
+    public static let koron = Accidental(.koron)
+    public static let other = Accidental(.other)
 }
 
 extension Accidental: Equatable { }
@@ -48,5 +107,21 @@ extension Accidental: Codable {
         case position
         case printStyle
         case value = ""
+    }
+    public init(from decoder: Decoder) throws {
+        // Decode attribute groups
+        self.printStyle = try PrintStyle(from: decoder)
+        // Decode attributes
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.cautionary = try container.decodeIfPresent(Bool.self, forKey: .cautionary)
+        self.editorial = try container.decodeIfPresent(Bool.self, forKey: .editorial)
+        self.parentheses = try container.decodeIfPresent(Bool.self, forKey: .parentheses)
+        self.bracket = try container.decodeIfPresent(Bool.self, forKey: .bracket)
+        self.size = try container.decodeIfPresent(SymbolSize.self, forKey: .size)
+        // Decode value
+        self.value = try container.decode(AccidentalValue.self, forKey: .value)
+    }
+    public func encode(to encoder: Encoder) throws {
+        fatalError("TODO: Accidental.encode(to:)")
     }
 }

--- a/Sources/MusicXML/Complex Types/Notations.swift
+++ b/Sources/MusicXML/Complex Types/Notations.swift
@@ -168,3 +168,12 @@ extension Notations: Codable {
         self.printObject = try attributesContainer.decodeIfPresent(Bool.self, forKey: .printObject)
     }
 }
+
+extension Notations: ExpressibleByArrayLiteral {
+
+    // MARK: - ExpressibleByArrayLiteral
+
+    public init(arrayLiteral elements: Notation...) {
+        self.init(elements)
+    }
+}

--- a/Sources/MusicXML/Complex Types/Note.swift
+++ b/Sources/MusicXML/Complex Types/Note.swift
@@ -13,29 +13,13 @@
 /// easier, as some programs handle one type of information much more readily than the other.
 public struct Note {
 
+    // MARK: - Instance Properties
+
+    // MARK: Kind
+
     public let kind: Kind
 
-    // MARK: - Attributes
-
-    public let position: Position
-    public let fontFamily: CommaSeparatedText?
-    public let fontStyle: FontStyle?
-    public let fontSize: FontSize?
-    public let fontWeight: FontWeight?
-    public let color: Color?
-    public let printStyle: PrintStyle?
-    public let printObject: Bool?
-    public let printDot: Bool?
-    public let printSpacing: Bool?
-    public let printLyric: Bool?
-    public let dynamics: Double?
-    public let endDynamics: Double?
-    public let attack: Divisions?
-    public let release: Divisions?
-    public let timeOnly: TimeOnly?
-    public let pizzicato: Bool?
-
-    // MARK: - Elements
+    // MARK: Elements
 
     public let instrument: Instrument?
     public let footnote: FormattedText?
@@ -54,15 +38,26 @@ public struct Note {
     public let lyrics: [Lyric]
     public let play: Play?
 
+    // MARK: Attributes
+
+    public let printObject: Bool?
+    public let printDot: Bool?
+    public let printSpacing: Bool?
+    public let printLyric: Bool?
+    public let dynamics: Double?
+    public let endDynamics: Double?
+    public let attack: Divisions?
+    public let release: Divisions?
+    public let timeOnly: TimeOnly?
+    public let pizzicato: Bool?
+
+    // MARK: Attribute Groups
+
+    public let printStyle: PrintStyle
+
     public init(
         kind: Kind,
-        position: Position = Position(),
-        fontFamily: CommaSeparatedText? = nil,
-        fontStyle: FontStyle? = nil,
-        fontSize: FontSize? = nil,
-        fontWeight: FontWeight? = nil,
-        color: Color? = nil,
-        printStyle: PrintStyle? = nil,
+        printStyle: PrintStyle = PrintStyle(),
         printObject: Bool? = nil,
         printDot: Bool? = nil,
         printSpacing: Bool? = nil,
@@ -91,12 +86,6 @@ public struct Note {
         play: Play? = nil
     ) {
         self.kind = kind
-        self.position = position
-        self.fontFamily = fontFamily
-        self.fontStyle = fontStyle
-        self.fontSize = fontSize
-        self.fontWeight = fontWeight
-        self.color = color
         self.printStyle = printStyle
         self.printObject = printObject
         self.printDot = printDot
@@ -128,39 +117,128 @@ public struct Note {
 }
 
 extension Note {
-    public struct Normal: Equatable {
-        public let chord: Bool
+
+    // MARK: - Initializers
+
+    // MARK: Normal
+
+    /// Creates a pitched, normal `Note`.
+    public init(
+        pitch: Pitch,
+        duration: Int,
+        ties: Ties = Ties(),
+        isChord: Bool = false,
+        printStyle: PrintStyle = PrintStyle(),
+        printObject: Bool? = nil,
+        printDot: Bool? = nil,
+        printSpacing: Bool? = nil,
+        printLyric: Bool? = nil,
+        dynamics: Double? = nil,
+        endDynamics: Double? = nil,
+        attack: Divisions? = nil,
+        release: Divisions? = nil,
+        timeOnly: TimeOnly? = nil,
+        pizzicato: Bool? = nil,
+        instrument: Instrument? = nil,
+        footnote: FormattedText? = nil,
+        level: Level? = nil,
+        voice: String? = nil,
+        type: NoteType? = nil,
+        dots: [EmptyPlacement]? = nil,
+        accidental: Accidental? = nil,
+        timeModification: TimeModification? = nil,
+        stem: Stem? = nil,
+        notehead: Notehead? = nil,
+        noteheadText: NoteheadText? = nil,
+        staff: Int? = nil,
+        beams: [Beam]? = nil,
+        notations: Notations? = nil,
+        lyrics: [Lyric] = [],
+        play: Play? = nil
+    ) {
+        self.kind = .normal(
+            Note.Normal(.pitch(pitch), duration: duration, ties: ties, isChord: isChord)
+        )
+        self.printStyle = printStyle
+        self.printObject = printObject
+        self.printDot = printDot
+        self.printSpacing = printSpacing
+        self.printLyric = printLyric
+        self.dynamics = dynamics
+        self.endDynamics = endDynamics
+        self.attack = attack
+        self.release = release
+        self.timeOnly = timeOnly
+        self.pizzicato = pizzicato
+        self.instrument = instrument
+        self.footnote = footnote
+        self.level = level
+        self.voice = voice
+        self.type = type
+        self.dots = dots
+        self.accidental = accidental
+        self.timeModification = timeModification
+        self.stem = stem
+        self.notehead = notehead
+        self.noteheadText = noteheadText
+        self.staff = staff
+        self.beams = beams
+        self.notations = notations
+        self.lyrics = lyrics
+        self.play = play
+    }
+}
+
+extension Note {
+
+    // MARK: Kinds of `Note`
+
+    public struct Normal {
+        public let isChord: Bool
         public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
         public let duration: Int
-        public let ties: Ties?
+        public let ties: Ties
 
-        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, duration: Int, ties: Ties? = nil) {
-            self.chord = chord
+        public init(
+            _ pitchUnpitchedOrRest: PitchUnpitchedOrRest,
+            duration: Int,
+            ties: Ties = Ties(),
+            isChord: Bool = false
+        ) {
+            self.isChord = isChord
             self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
             self.duration = duration
             self.ties = ties
         }
     }
 
-    public struct Cue: Equatable {
-        public let chord: Bool
+    public struct Cue {
+        public let isChord: Bool
         public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
         public let duration: Int
 
-        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, duration: Int) {
-            self.chord = chord
+        public init(
+            _ pitchUnpitchedOrRest: PitchUnpitchedOrRest,
+            duration: Int,
+            isChord: Bool = false
+        ) {
+            self.isChord = isChord
             self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
             self.duration = duration
         }
     }
 
-    public struct Grace: Equatable {
-        public let chord: Bool
+    public struct Grace {
+        public let isChord: Bool
         public let pitchUnpitchedOrRest: PitchUnpitchedOrRest
-        public let ties: Ties?
+        public let ties: Ties
 
-        public init(chord: Bool = false, pitchUnpitchedOrRest: PitchUnpitchedOrRest, ties: Ties? = nil) {
-            self.chord = chord
+        public init(
+            _ pitchUnpitchedOrRest: PitchUnpitchedOrRest,
+            ties: Ties = Ties(),
+            chord: Bool = false
+        ) {
+            self.isChord = chord
             self.pitchUnpitchedOrRest = pitchUnpitchedOrRest
             self.ties = ties
         }
@@ -173,15 +251,14 @@ extension Note {
     }
 }
 
+extension Note.Normal: Equatable { }
+extension Note.Cue: Equatable { }
+extension Note.Grace: Equatable { }
+
 extension Note: Equatable { }
 extension Note: Codable {
     enum CodingKeys: String, CodingKey {
         // Attributes
-        case fontFamily = "font-family"
-        case fontStyle = "font-style"
-        case fontSize = "font-size"
-        case fontWeight = "font-weight"
-        case color
         case printStyle = "print-style"
         case printObject = "print-object"
         case printDot = "print-dot"
@@ -216,22 +293,19 @@ extension Note: Codable {
         case chord
         case duration
         case tie
-        
+        // Kind
         case pitch
         case rest
         case unpitched
     }
 
     public init(from decoder: Decoder) throws {
+
+        // Decode attribute groups
+        self.printStyle = try PrintStyle(from: decoder)
+
+        // Decode attributes
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        // Attributes
-        self.position = try Position(from: decoder)
-        self.fontFamily = try container.decodeIfPresent(CommaSeparatedText.self, forKey: .fontFamily)
-        self.fontStyle = try container.decodeIfPresent(FontStyle.self, forKey: .fontStyle)
-        self.fontSize = try container.decodeIfPresent(FontSize.self, forKey: .fontSize)
-        self.fontWeight = try container.decodeIfPresent(FontWeight.self, forKey: .fontWeight)
-        self.color = try container.decodeIfPresent(Color.self, forKey: .color)
-        self.printStyle = try container.decodeIfPresent(PrintStyle.self, forKey: .printStyle)
         self.printObject = try container.decodeIfPresent(Bool.self, forKey: .printObject)
         self.printDot = try container.decodeIfPresent(Bool.self, forKey: .printDot)
         self.printSpacing = try container.decodeIfPresent(Bool.self, forKey: .printSpacing)
@@ -242,13 +316,13 @@ extension Note: Codable {
         self.release = try container.decodeIfPresent(Divisions.self, forKey: .release)
         self.timeOnly = try container.decodeIfPresent(TimeOnly.self, forKey: .timeOnly)
         self.pizzicato = try container.decodeIfPresent(Bool.self, forKey: .pizzicato)
+
         // Decode elements
         self.instrument = try container.decodeIfPresent(Instrument.self, forKey: .instrument)
         self.footnote = try container.decodeIfPresent(FormattedText.self, forKey: .footnote)
         self.level = try container.decodeIfPresent(Level.self, forKey: .level)
         self.voice = try container.decodeIfPresent(String.self, forKey: .voice)
         self.type = try container.decodeIfPresent(NoteType.self, forKey: .type)
-
         self.dots = try container.decodeIfPresent([EmptyPlacement].self, forKey: .dots)
         self.accidental = try container.decodeIfPresent(Accidental.self, forKey: .accidental)
         self.timeModification = try container.decodeIfPresent(TimeModification.self, forKey: .timeModification)
@@ -261,8 +335,22 @@ extension Note: Codable {
         self.lyrics = try container.decode([Lyric].self, forKey: .lyrics)
         self.play = try container.decodeIfPresent(Play.self, forKey: .play)
 
-        let chordEmptyElement = try container.decodeIfPresent(Empty.self, forKey: .chord)
-        let ties = try container.decodeIfPresent([Tie].self, forKey: .tie).map(Ties.init)
+        // Decode kind
+
+        // Only `normal` and `grace` notes have ties, so defer `Tie` parsing and initialization
+        // until we know we need them.
+        func ties() throws -> Ties {
+            return Ties(ties: try container.decode([Tie].self, forKey: .tie))
+        }
+
+        // Only `normal` and `cue` notes have durations, so defer `duration` parsing until we know
+        // we need it.
+        func duration() throws -> Int {
+            return try container.decode(Int.self, forKey: .duration)
+        }
+
+        // The `Note` is a chord if it contains an empty `<chord/>` element.
+        let isChord = container.contains(.chord)
 
         // Decode pitch / unpitched / rest
         let pitchUnpitchedOrRest: PitchUnpitchedOrRest
@@ -277,35 +365,25 @@ extension Note: Codable {
             pitchUnpitchedOrRest = .unpitched(unpitched)
         }
 
-        // Decode kind
         if container.contains(.grace) {
             self.kind = .grace(
-                Note.Grace(
-                    chord: chordEmptyElement != nil,
-                    pitchUnpitchedOrRest: pitchUnpitchedOrRest,
-                    ties: ties
-                )
+                Note.Grace(pitchUnpitchedOrRest, ties: try ties(), chord: isChord)
             )
         } else if container.contains(.cue) {
             self.kind = .cue(
-                Note.Cue(
-                    chord: chordEmptyElement != nil,
-                    pitchUnpitchedOrRest: pitchUnpitchedOrRest,
-                    duration: try container.decode(Int.self, forKey: .duration)
-                )
+                Note.Cue(pitchUnpitchedOrRest, duration: try duration(), isChord: isChord)
             )
         } else {
             self.kind = .normal(
-                Normal(
-                    chord: chordEmptyElement != nil,
-                    pitchUnpitchedOrRest: pitchUnpitchedOrRest,
-                    duration: try container.decode(Int.self, forKey: .duration),
-                    ties: ties
+                Normal(pitchUnpitchedOrRest,
+                    duration: try duration(),
+                    ties: try ties(),
+                    isChord: isChord
                 )
             )
         }
     }
     public func encode(to encoder: Encoder) throws {
-        fatalError()
+        fatalError("TODO: Note.encode(to:)")
     }
 }

--- a/Sources/MusicXML/Complex Types/Tie.swift
+++ b/Sources/MusicXML/Complex Types/Tie.swift
@@ -8,13 +8,22 @@
 /// The tie element indicates that a tie begins or ends with this note. The tie element indicates
 /// sound; the tied element indicates notation.
 public struct Tie {
+
     public var type: StartStop
     public var timeOnly: TimeOnly?
 
-    public init(type: StartStop, timeOnly: TimeOnly? = nil) {
+    public init(_ type: StartStop, timeOnly: TimeOnly? = nil) {
         self.type = type
         self.timeOnly = timeOnly
     }
+}
+
+extension Tie {
+
+    // MARK: Type Properties
+
+    public static let start = Tie(.start)
+    public static let stop = Tie(.stop)
 }
 
 extension Tie: Equatable { }

--- a/Sources/MusicXML/Complex Types/Ties.swift
+++ b/Sources/MusicXML/Complex Types/Ties.swift
@@ -14,6 +14,11 @@ public struct Ties {
         self.stop = stop
     }
 
+    public init(start: Bool, stop: Bool) {
+        self.start = start ? Tie(.start) : nil
+        self.stop = stop ? Tie(.stop) : nil
+    }
+
     init(ties: [Tie]) {
         var startTie: Tie?
         var stopTie: Tie?

--- a/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
@@ -16,7 +16,7 @@ class AccidentalTests: XCTestCase {
         <accidental>sharp</accidental>
         """
         let decoded = try XMLDecoder().decode(Accidental.self, from: xml.data(using: .utf8)!)
-        let expected = Accidental(value: .sharp)
+        let expected = Accidental.sharp
         XCTAssertEqual(decoded, expected)
     }
 

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -80,7 +80,8 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(Note.Normal(.pitch(Pitch(step: .c, octave: 4)), duration: 56)),
+            pitch: Pitch(step: .c, octave: 4),
+            duration: 56,
             voice: "1",
             type: .quarter,
             timeModification: TimeModification(actualNotes: 3, normalNotes: 2),
@@ -102,9 +103,9 @@ class NoteTests: XCTestCase {
         </note>
         """
         let expected = Note(
-            kind: .normal(
-                Note.Normal(.pitch(Pitch(step: .e, octave: 5)), duration: 1, isChord: true)
-            ),
+            pitch: Pitch(step: .e, octave: 5),
+            duration: 1,
+            isChord: true,
             voice: "1",
             type: .quarter
         )
@@ -149,7 +150,8 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(Note.Normal(.pitch(Pitch(step: .f, alter: 1, octave: 5)), duration: 1)),
+            pitch: Pitch(step: .f, alter: 1, octave: 5),
+            duration: 1,
             printStyle: PrintStyle(position: Position(defaultX: 368.91, defaultY: 0)),
             voice: "1",
             type: .sixteenth,
@@ -183,17 +185,17 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(.pitch(Pitch(step: .a, octave: 4)),
-                    duration: 4,
-                    ties: Ties(start: Tie(type: .start), stop: Tie(type: .stop))
-                )
-            ),
+            pitch: Pitch(step: .a, octave: 4),
+            duration: 4,
+            ties: Ties(start: true, stop: true),
             printStyle: PrintStyle(position: Position(defaultX: 483.50, defaultY: -25.00)),
             voice: "1",
             type: .quarter,
             stem: .up,
-            notations: Notations([.tied(Tied(type: .stop)), .tied(Tied(type: .start))])
+            notations: [
+                .tied(Tied(type: .stop)),
+                .tied(Tied(type: .start))
+            ]
         )
         XCTAssertEqual(decoded, expected)
     }
@@ -223,7 +225,9 @@ class NoteTests: XCTestCase {
             voice: "1",
             type: .eighth,
             stem: Stem(.down, position: Position(defaultY: -70)),
-            beams: [Beam(value: .begin, number: .one)]
+            beams: [
+                Beam(value: .begin, number: .one)
+            ]
         )
         XCTAssertEqual(decoded, expected)
     }
@@ -244,9 +248,9 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(.pitch(Pitch(step: .c, octave: 5)), duration: 1, isChord: true)
-            ),
+            pitch: Pitch(step: .c, octave: 5),
+            duration: 1,
+            isChord: true,
             voice: "1",
             type: .quarter,
             notehead: Notehead(value: .normal, parentheses: true)

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -26,13 +26,8 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    chord: false,
-                    pitchUnpitchedOrRest: .pitch(Pitch(step: .c, alter: -1.5, octave: 4)),
-                    duration: 1
-                )
-            ),
+            pitch: Pitch(step: .c, alter: -1.5, octave: 4),
+            duration: 1,
             voice: "1",
             type: .quarter
         )
@@ -55,15 +50,11 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .pitch(Pitch(step: .g, alter: 1, octave: 2)),
-                    duration: 1
-                )
-            ),
+            pitch: Pitch(step: .g, alter: 1, octave: 2),
+            duration: 1,
             voice: "1",
             type: .quarter,
-            accidental: Accidental(value: .sharp)
+            accidental: .sharp
         )
         XCTAssertEqual(decoded, expected)
     }
@@ -89,12 +80,7 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .pitch(Pitch(step: .c, octave: 4)),
-                    duration: 56
-                )
-            ),
+            kind: .normal(Note.Normal(.pitch(Pitch(step: .c, octave: 4)), duration: 56)),
             voice: "1",
             type: .quarter,
             timeModification: TimeModification(actualNotes: 3, normalNotes: 2),
@@ -115,7 +101,13 @@ class NoteTests: XCTestCase {
           <type>quarter</type>
         </note>
         """
-        let expected = Note(kind: .normal(Note.Normal(chord: true, pitchUnpitchedOrRest: .pitch(Pitch(step: .e, octave: 5)), duration: 1)), voice: "1", type: .quarter)
+        let expected = Note(
+            kind: .normal(
+                Note.Normal(.pitch(Pitch(step: .e, octave: 5)), duration: 1, isChord: true)
+            ),
+            voice: "1",
+            type: .quarter
+        )
         try assertDecoded(xml, equals: expected)
     }
 
@@ -131,12 +123,7 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .rest(Rest()),
-                    duration: 48
-                )
-            ),
+            kind: .normal(Note.Normal(.rest(Rest()), duration: 48)),
             voice: "1",
             type: .quarter,
             dots: [EmptyPlacement()]
@@ -162,15 +149,8 @@ class NoteTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .pitch(
-                        Pitch(step: .f, alter: 1, octave: 5)
-                    ),
-                    duration: 1
-                )
-            ),
-            position: Position(defaultX: 368.91, defaultY: 0),
+            kind: .normal(Note.Normal(.pitch(Pitch(step: .f, alter: 1, octave: 5)), duration: 1)),
+            printStyle: PrintStyle(position: Position(defaultX: 368.91, defaultY: 0)),
             voice: "1",
             type: .sixteenth,
             stem: .down,
@@ -204,15 +184,12 @@ class NoteTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
             kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .pitch(
-                        Pitch(step: .a, octave: 4)
-                    ),
+                Note.Normal(.pitch(Pitch(step: .a, octave: 4)),
                     duration: 4,
                     ties: Ties(start: Tie(type: .start), stop: Tie(type: .stop))
                 )
             ),
-            position: Position(defaultX: 483.50, defaultY: -25.00),
+            printStyle: PrintStyle(position: Position(defaultX: 483.50, defaultY: -25.00)),
             voice: "1",
             type: .quarter,
             stem: .up,
@@ -239,17 +216,9 @@ class NoteTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
             kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: .unpitched(
-                        Unpitched(
-                            displayStep: .f,
-                            displayOctave: 4
-                        )
-                    ),
-                    duration: 1
-                )
+                Note.Normal(.unpitched(Unpitched(displayStep: .f, displayOctave: 4)), duration: 1)
             ),
-            position: Position(defaultX: 68),
+            printStyle: PrintStyle(position: Position(defaultX: 68)),
             instrument: Instrument(id: "P1-X2"),
             voice: "1",
             type: .eighth,
@@ -276,13 +245,7 @@ class NoteTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
             kind: .normal(
-                Note.Normal(
-                    chord: true,
-                    pitchUnpitchedOrRest: .pitch(
-                        Pitch(step: .c, octave: 5)
-                    ),
-                    duration: 1
-                )
+                Note.Normal(.pitch(Pitch(step: .c, octave: 5)), duration: 1, isChord: true)
             ),
             voice: "1",
             type: .quarter,

--- a/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
@@ -138,48 +138,28 @@ class PartwiseMeasureTests: XCTestCase {
                 ),
                 .note(
                     Note(
-                        kind: .normal(
-                            Note.Normal(
-                                pitchUnpitchedOrRest: .pitch(Pitch(step: .g, octave: 2)),
-                                duration: 1
-                            )
-                        ),
+                        kind: .normal(Note.Normal(.pitch(Pitch(step: .g, octave: 2)), duration: 1)),
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(
-                            Note.Normal(
-                                pitchUnpitchedOrRest: .pitch(Pitch(step: .a, octave: 2)),
-                                duration: 1
-                            )
-                        ),
+                        kind: .normal(Note.Normal(.pitch(Pitch(step: .a, octave: 2)), duration: 1)),
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(
-                            Note.Normal(
-                                pitchUnpitchedOrRest: .pitch(Pitch(step: .b, octave: 2)),
-                                duration: 1
-                            )
-                        ),
+                        kind: .normal(Note.Normal(.pitch(Pitch(step: .b, octave: 2)), duration: 1)),
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(
-                            Note.Normal(
-                                pitchUnpitchedOrRest: .pitch(Pitch(step: .c, octave: 3)),
-                                duration: 1
-                            )
-                        ),
+                        kind: .normal(Note.Normal(.pitch(Pitch(step: .c, octave: 3)), duration: 1)),
                         voice: "1",
                         type: .quarter
                     )

--- a/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwiseMeasureTests.swift
@@ -131,35 +131,37 @@ class PartwiseMeasureTests: XCTestCase {
                         divisions: 1,
                         keys: [Key(fifths: 0, mode: .major)],
                         times: [Time(4, 4, symbol: .common)],
-                        clefs: [
-                            Clef(sign: .g, line: 2)
-                        ]
+                        clefs: [Clef(sign: .g, line: 2)]
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(Note.Normal(.pitch(Pitch(step: .g, octave: 2)), duration: 1)),
+                        pitch: Pitch(step: .g, octave: 2),
+                        duration: 1,
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(Note.Normal(.pitch(Pitch(step: .a, octave: 2)), duration: 1)),
+                        pitch: Pitch(step: .a, octave: 2),
+                        duration: 1,
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(Note.Normal(.pitch(Pitch(step: .b, octave: 2)), duration: 1)),
+                        pitch: Pitch(step: .b, octave: 2),
+                        duration: 1,
                         voice: "1",
                         type: .quarter
                     )
                 ),
                 .note(
                     Note(
-                        kind: .normal(Note.Normal(.pitch(Pitch(step: .c, octave: 3)), duration: 1)),
+                        pitch: Pitch(step: .c, octave: 3),
+                        duration: 1,
                         voice: "1",
                         type: .quarter
                     )

--- a/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
@@ -86,36 +86,32 @@ class PartwisePartTests: XCTestCase {
                         ),
                         .note(
                             Note(
-                                kind: .normal(
-                                    Note.Normal(.pitch(Pitch(step: .g, octave: 2)), duration: 1)
-                                ),
+                                pitch: Pitch(step: .g, octave: 2),
+                                duration: 1,
                                 voice: "1",
                                 type: .quarter
                             )
                         ),
                         .note(
                             Note(
-                                kind: .normal(
-                                    Note.Normal(.pitch(Pitch(step: .a, octave: 2)), duration: 1)
-                                ),
+                                pitch: Pitch(step: .a, octave: 2),
+                                duration: 1,
                                 voice: "1",
                                 type: .quarter
                             )
                         ),
                         .note(
                             Note(
-                                kind: .normal(
-                                    Note.Normal(.pitch(Pitch(step: .b, octave: 2)), duration: 1)
-                                ),
+                                pitch: Pitch(step: .b, octave: 2),
+                                duration: 1,
                                 voice: "1",
                                 type: .quarter
                             )
                         ),
                         .note(
                             Note(
-                                kind: .normal(
-                                    Note.Normal(.pitch(Pitch(step: .c, octave: 3)), duration: 1)
-                                ),
+                                pitch: Pitch(step: .c, octave: 3),
+                                duration: 1,
                                 voice: "1",
                                 type: .quarter
                             )

--- a/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartwisePartTests.swift
@@ -87,10 +87,7 @@ class PartwisePartTests: XCTestCase {
                         .note(
                             Note(
                                 kind: .normal(
-                                    Note.Normal(
-                                        pitchUnpitchedOrRest: .pitch(Pitch(step: .g, octave: 2)),
-                                        duration: 1
-                                    )
+                                    Note.Normal(.pitch(Pitch(step: .g, octave: 2)), duration: 1)
                                 ),
                                 voice: "1",
                                 type: .quarter
@@ -99,10 +96,7 @@ class PartwisePartTests: XCTestCase {
                         .note(
                             Note(
                                 kind: .normal(
-                                    Note.Normal(
-                                        pitchUnpitchedOrRest: .pitch(Pitch(step: .a, octave: 2)),
-                                        duration: 1
-                                    )
+                                    Note.Normal(.pitch(Pitch(step: .a, octave: 2)), duration: 1)
                                 ),
                                 voice: "1",
                                 type: .quarter
@@ -111,10 +105,7 @@ class PartwisePartTests: XCTestCase {
                         .note(
                             Note(
                                 kind: .normal(
-                                    Note.Normal(
-                                        pitchUnpitchedOrRest: .pitch(Pitch(step: .b, octave: 2)),
-                                        duration: 1
-                                    )
+                                    Note.Normal(.pitch(Pitch(step: .b, octave: 2)), duration: 1)
                                 ),
                                 voice: "1",
                                 type: .quarter
@@ -123,10 +114,7 @@ class PartwisePartTests: XCTestCase {
                         .note(
                             Note(
                                 kind: .normal(
-                                    Note.Normal(
-                                        pitchUnpitchedOrRest: .pitch(Pitch(step: .c, octave: 3)),
-                                        duration: 1
-                                    )
+                                    Note.Normal(.pitch(Pitch(step: .c, octave: 3)), duration: 1)
                                 ),
                                 voice: "1",
                                 type: .quarter

--- a/Tests/MusicXMLTests/HelloWorld.swift
+++ b/Tests/MusicXMLTests/HelloWorld.swift
@@ -51,51 +51,35 @@ class HelloWorld: XCTestCase {
         </score-partwise>
         """
         let decoded = try MusicXML(string: xml)
-        
-        let expected = MusicXML(
-            Score(
-                traversal: .partwise(
-                    Partwise(
-                        header: Header(
-                            partList: PartList([.part(ScorePart(id: "P1", name: "Music"))])
-                        ),
-                        parts: [
-                            Partwise.Part(
-                                id: "P1",
-                                measures: [
-                                    Partwise.Measure(
-                                        number: "1",
-                                        musicData: [
-                                            .attributes(
-                                                Attributes(
-                                                    divisions: 1,
-                                                    keys: [Key(fifths: 0)],
-                                                    times: [Time(4, 4)],
-                                                    clefs: [Clef(sign: .g, line: 2)]
-                                                )
-                                            ),
-                                            .note(
-                                                Note(
-                                                    kind: .normal(
-                                                        Note.Normal(
-                                                            pitchUnpitchedOrRest: .pitch(
-                                                                Pitch(step: .c, octave: 4)
-                                                            ),
-                                                            duration: 4
-                                                        )
-                                                    ),
-                                                    type: .whole
-                                                )
-                                            )
-                                        ]
-                                    )
-                                ]
-                            )
-                        ]
-                    )
-                )
-            )
+
+        // Create the note
+        let note = Note(pitch: Pitch(step: .c, octave: 4), duration: 4, type: .whole)
+        // Create measure attributes
+        let attributes = Attributes(
+            divisions: 1,
+            keys: [Key(fifths: 0)],
+            times: [Time(4,4)],
+            clefs: [Clef(sign: .g, line: 2)]
         )
-        XCTAssertEqual(decoded, expected)
+        // Create the measure
+        let measure = Partwise.Measure(
+            number: "1",
+            musicData: [
+                .attributes(attributes),
+                .note(note)
+            ]
+        )
+        // Create the part
+        let part = Partwise.Part(id: "P1", measures: [measure])
+        // Create the score header
+        let header = Header(partList: PartList([.part(ScorePart(id: "P1", name: "Music"))]))
+        // Create the traversal
+        let traversal = Partwise(header: header, parts: [part])
+        // Create the score
+        let score = Score(traversal: .partwise(traversal))
+        // Create the MusicXML
+        let musicXML = MusicXML(score)
+
+        XCTAssertEqual(decoded, musicXML)
     }
 }

--- a/Tests/MusicXMLTests/LilyPondTests/DirectionsTests.swift
+++ b/Tests/MusicXMLTests/LilyPondTests/DirectionsTests.swift
@@ -25,12 +25,7 @@ class DirectionsTests: XCTestCase {
         """
         let decoded = try XMLDecoder().decode(Note.self, from: xml.data(using: .utf8)!)
         let expected = Note(
-            kind: .normal(
-                Note.Normal(
-                    pitchUnpitchedOrRest: PitchUnpitchedOrRest.rest(Rest()),
-                    duration: 1
-                )
-            ),
+            kind: .normal(Note.Normal(.rest(Rest()), duration: 1)),
             voice: "1",
             type: NoteType(.quarter),
             lyrics: [


### PR DESCRIPTION
This PR adds a convenience initializer to `Note` for normal, pitched notes.

Along the way, various normalizations of property names are made.

Nestles up against #98.