### PR TITLE
De-label value arguments

### DIFF
--- a/Sources/MusicXML/Complex Types/AccidentalMark.swift
+++ b/Sources/MusicXML/Complex Types/AccidentalMark.swift
@@ -19,7 +19,7 @@ public struct AccidentalMark {
     public var position: Position?
     public var printStyle: PrintStyle?
 
-    public init(value: AccidentalValue, placement: AboveBelow? = nil, position: Position? = nil, printStyle: PrintStyle? = nil) {
+    public init(_ value: AccidentalValue, placement: AboveBelow? = nil, position: Position? = nil, printStyle: PrintStyle? = nil) {
         self.value = value
         self.placement = placement
         self.position = position

--- a/Sources/MusicXML/Complex Types/AccidentalText.swift
+++ b/Sources/MusicXML/Complex Types/AccidentalText.swift
@@ -25,7 +25,22 @@ public struct AccidentalText {
     // MARK: - Elements
     public let value: AccidentalValue
 
-    public init(justify: LeftCenterRight? = nil, printStyle: PrintStyle = PrintStyle(), hAlign: LeftCenterRight? = nil, vAlign: VAlign? = nil, underline: Int? = nil, overline: Int? = nil, lineThrough: Int? = nil, rotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, lineHeight: NumberOrNormal? = nil, direction: TextDirection? = nil, enclosure: EnclosureShape? = nil, value: AccidentalValue) {
+    public init(
+        _ value: AccidentalValue,
+        justify: LeftCenterRight? = nil,
+        printStyle: PrintStyle = PrintStyle(),
+        hAlign: LeftCenterRight? = nil,
+        vAlign: VAlign? = nil,
+        underline: Int? = nil,
+        overline: Int? = nil,
+        lineThrough: Int? = nil,
+        rotation: Double? = nil,
+        letterSpacing: NumberOrNormal? = nil,
+        lineHeight: NumberOrNormal? = nil,
+        direction: TextDirection? = nil,
+        enclosure: EnclosureShape? = nil
+    ) {
+        self.value = value
         self.justify = justify
         self.printStyle = printStyle
         self.hAlign = hAlign
@@ -38,7 +53,6 @@ public struct AccidentalText {
         self.lineHeight = lineHeight
         self.direction = direction
         self.enclosure = enclosure
-        self.value = value
     }
 }
 

--- a/Sources/MusicXML/Complex Types/BassAlter.swift
+++ b/Sources/MusicXML/Complex Types/BassAlter.swift
@@ -13,7 +13,7 @@ public struct BassAlter {
     public let printStyle: PrintStyle?
     public let location: LeftRight?
 
-    public init(value: Double, printObject: Bool? = nil, printStyle: PrintStyle = PrintStyle(), location: LeftRight? = nil) {
+    public init(_ value: Double, printObject: Bool? = nil, printStyle: PrintStyle = PrintStyle(), location: LeftRight? = nil) {
         self.value = value
         self.printObject = printObject
         self.printStyle = printStyle
@@ -40,6 +40,6 @@ extension BassAlter: Codable {
 
 extension BassAlter: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Double) {
-        self.init(value: value)
+        self.init(value)
     }
 }

--- a/Sources/MusicXML/Complex Types/Beam.swift
+++ b/Sources/MusicXML/Complex Types/Beam.swift
@@ -18,7 +18,7 @@ public struct Beam {
     public var fan: Fan?
     public var color: Color?
 
-    public init(value: BeamValue, number: BeamLevel? = nil, repeater: Bool? = nil, fan: Fan? = nil, color: Color? = nil) {
+    public init(_ value: BeamValue, number: BeamLevel? = nil, repeater: Bool? = nil, fan: Fan? = nil, color: Color? = nil) {
         self.value = value
         self.number = number
         self.repeater = repeater

--- a/Sources/MusicXML/Complex Types/Beater.swift
+++ b/Sources/MusicXML/Complex Types/Beater.swift
@@ -9,7 +9,7 @@ public struct Beater {
     public let value: BeaterValue
     public let tip: TipDirection?
 
-    public init(value: BeaterValue, tip: TipDirection? = nil) {
+    public init(_ value: BeaterValue, tip: TipDirection? = nil) {
         self.value = value
         self.tip = tip
     }

--- a/Sources/MusicXML/Complex Types/Creator.swift
+++ b/Sources/MusicXML/Complex Types/Creator.swift
@@ -23,11 +23,6 @@ public struct Creator {
         self.value = value
         self.type = type
     }
-
-    public init(value: String, type: String? = nil) {
-        self.value = value
-        self.type = type
-    }
 }
 
 extension Creator: Equatable { }

--- a/Sources/MusicXML/Complex Types/Distance.swift
+++ b/Sources/MusicXML/Complex Types/Distance.swift
@@ -10,7 +10,7 @@ public struct Distance {
     public let value: Tenths
     public let type: DistanceType
 
-    public init(value: Tenths, type: DistanceType) {
+    public init(_ value: Tenths, type: DistanceType) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/Feature.swift
+++ b/Sources/MusicXML/Complex Types/Feature.swift
@@ -12,7 +12,7 @@ public struct Feature {
     public let value: String
     public let type: String?
 
-    public init(value: String, type: String? = nil) {
+    public init(_ value: String, type: String? = nil) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/Fermata.swift
+++ b/Sources/MusicXML/Complex Types/Fermata.swift
@@ -18,7 +18,7 @@ public struct Fermata {
     public var type: UprightInverted?
     public var printStyle: PrintStyle?
 
-    public init(value: FermataShape, type: UprightInverted? = nil, printStyle: PrintStyle? = nil) {
+    public init(_ value: FermataShape, type: UprightInverted? = nil, printStyle: PrintStyle? = nil) {
         self.value = value
         self.type = type
         self.printStyle = printStyle

--- a/Sources/MusicXML/Complex Types/FirstFret.swift
+++ b/Sources/MusicXML/Complex Types/FirstFret.swift
@@ -12,7 +12,7 @@ public struct FirstFret {
     public let text: String?
     public let location: LeftRight?
 
-    public init(value: Int, text: String? = nil, location: LeftRight? = nil) {
+    public init(_ value: Int, text: String? = nil, location: LeftRight? = nil) {
         self.value = value
         self.text = text
         self.location = location

--- a/Sources/MusicXML/Complex Types/Glissando.swift
+++ b/Sources/MusicXML/Complex Types/Glissando.swift
@@ -17,7 +17,7 @@ public struct Glissando {
     public let dashedFormatting: DashedFormatting?
     public let printStyle: PrintStyle?
 
-    public init(value: String, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, printStyle: PrintStyle? = nil) {
+    public init(_ value: String, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting? = nil, printStyle: PrintStyle? = nil) {
         self.value = value
         self.type = type
         self.number = number

--- a/Sources/MusicXML/Complex Types/GroupBarline.swift
+++ b/Sources/MusicXML/Complex Types/GroupBarline.swift
@@ -10,7 +10,7 @@ public struct GroupBarline {
     public var value: GroupBarlineValue
     public var color: Color?
 
-    public init(value: GroupBarlineValue, color: Color? = nil) {
+    public init(_ value: GroupBarlineValue, color: Color? = nil) {
         self.value = value
         self.color = color
     }

--- a/Sources/MusicXML/Complex Types/GroupName.swift
+++ b/Sources/MusicXML/Complex Types/GroupName.swift
@@ -13,7 +13,7 @@ public struct GroupName {
     public let printStyle: PrintStyle?
     public let justify: Justify?
 
-    public init(value: String, printStyle: PrintStyle? = nil, justify: Justify? = nil) {
+    public init(_ value: String, printStyle: PrintStyle? = nil, justify: Justify? = nil) {
         self.value = value
         self.printStyle = printStyle
         self.justify = justify

--- a/Sources/MusicXML/Complex Types/GroupSymbol.swift
+++ b/Sources/MusicXML/Complex Types/GroupSymbol.swift
@@ -13,7 +13,7 @@ public struct GroupSymbol {
     public var position: Position?
     public var color: Color?
 
-    public init(value: GroupSymbolValue, position: Position? = nil, color: Color? = nil) {
+    public init(_ value: GroupSymbolValue, position: Position? = nil, color: Color? = nil) {
         self.value = value
         self.position = position
         self.color = color

--- a/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
+++ b/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
@@ -17,7 +17,7 @@ public struct HammerOnPullOff {
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
 
-    public init(value: String, type: StartStop, number: Int? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+    public init(_ value: String, type: StartStop, number: Int? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
         self.value = value
         self.type = type
         self.number = number

--- a/Sources/MusicXML/Complex Types/Handbell.swift
+++ b/Sources/MusicXML/Complex Types/Handbell.swift
@@ -12,7 +12,7 @@ public struct Handbell {
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
 
-    public init(value: HandbellValue, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+    public init(_ value: HandbellValue, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
         self.value = value
         self.printStyle = printStyle
         self.placement = placement

--- a/Sources/MusicXML/Complex Types/HoleClosed.swift
+++ b/Sources/MusicXML/Complex Types/HoleClosed.swift
@@ -12,7 +12,7 @@ public struct HoleClosed {
     /// element value is half.
     public let location: HoleClosedLocation?
 
-    public init(value: HoleClosedValue, location: HoleClosedLocation? = nil) {
+    public init(_ value: HoleClosedValue, location: HoleClosedLocation? = nil) {
         self.value = value
         self.location = location
     }

--- a/Sources/MusicXML/Complex Types/LineWidth.swift
+++ b/Sources/MusicXML/Complex Types/LineWidth.swift
@@ -11,7 +11,7 @@ public struct LineWidth {
     public let value: Tenths
     public let type: LineWidthType
 
-    public init(value: Tenths, type: LineWidthType) {
+    public init(_ value: Tenths, type: LineWidthType) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/MIDIDevice.swift
+++ b/Sources/MusicXML/Complex Types/MIDIDevice.swift
@@ -19,7 +19,7 @@ public struct MIDIDevice {
     /// missing, the device assignment affects all score-instrument elements in the score-part.
     public var id: String?
 
-    public init(value: String? = nil, port: Int? = nil, id: String? = nil) {
+    public init(_ value: String? = nil, port: Int? = nil, id: String? = nil) {
         self.value = value
         self.port = port
         self.id = id

--- a/Sources/MusicXML/Complex Types/MeasureNumbering.swift
+++ b/Sources/MusicXML/Complex Types/MeasureNumbering.swift
@@ -11,7 +11,7 @@ public struct MeasureNumbering {
     public let value: MeasureNumberingValue
     public let printStyleAlign: PrintStyleAlign?
 
-    public init(value: MeasureNumberingValue, printStyleAlign: PrintStyleAlign? = nil) {
+    public init(_ value: MeasureNumberingValue, printStyleAlign: PrintStyleAlign? = nil) {
         self.value = value
         self.printStyleAlign = printStyleAlign
     }

--- a/Sources/MusicXML/Complex Types/MetronomeBeam.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeBeam.swift
@@ -11,7 +11,7 @@ public struct MetronomeBeam {
     public let value: BeamValue
     public let number: BeamLevel?
 
-    public init(value: BeamValue, number: BeamLevel? = nil) {
+    public init(_ value: BeamValue, number: BeamLevel? = nil) {
         self.value = value
         self.number = number
     }

--- a/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
@@ -13,7 +13,7 @@ public struct MetronomeTuplet {
     public let bracket: Bool?
     public let showNumber: ShowTuplet?
 
-    public init(value: TimeModification, type: StartStop, bracket: Bool? = nil, showNumber: ShowTuplet? = nil) {
+    public init(_ value: TimeModification, type: StartStop, bracket: Bool? = nil, showNumber: ShowTuplet? = nil) {
         self.value = value
         self.type = type
         self.bracket = bracket

--- a/Sources/MusicXML/Complex Types/MiscellaneousField.swift
+++ b/Sources/MusicXML/Complex Types/MiscellaneousField.swift
@@ -11,12 +11,20 @@ import XMLCoder
 /// can go in a miscellaneous-field element. The required name attribute indicates the type of
 /// metadata the element content represents.
 public struct MiscellaneousField {
-    // MARK: - Attributes
+
+    // MARK: - Instance Properties
+
+    // MARK: Attributes
+
     public let name: String
-    // MARK: - Value
+
+    // MARK: Value
+
     public let value: String
 
-    public init(name: String, value: String) {
+    // MARK: - Initializers
+
+    public init(_ value: String, name: String) {
         self.name = name
         self.value = value
     }

--- a/Sources/MusicXML/Complex Types/MultipleRest.swift
+++ b/Sources/MusicXML/Complex Types/MultipleRest.swift
@@ -10,17 +10,21 @@
 /// text is ignored when the type is stop.
 public struct MultipleRest {
 
-    // MARK: - Attributes
+    // MARK: - Instance Properties
+
+    // MARK: Attributes
 
     public var useSymbols: Bool?
 
-    // MARK: - Value
+    // MARK: Value
 
     public var value: Int
 
-    public init(useSymbols: Bool? = nil, value: Int) {
-        self.useSymbols = useSymbols
+    // MARK: - Initializers
+
+    public init(_ value: Int, useSymbols: Bool? = nil) {
         self.value = value
+        self.useSymbols = useSymbols
     }
 }
 

--- a/Sources/MusicXML/Complex Types/NoteSize.swift
+++ b/Sources/MusicXML/Complex Types/NoteSize.swift
@@ -15,7 +15,7 @@ public struct NoteSize {
     public let value: NonNegativeDecimal
     public let type: NoteSizeType
 
-    public init(value: NonNegativeDecimal, type: NoteSizeType) {
+    public init(_ value: NonNegativeDecimal, type: NoteSizeType) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/Notehead.swift
+++ b/Sources/MusicXML/Complex Types/Notehead.swift
@@ -15,7 +15,7 @@ public struct Notehead {
     public let font: Font
     public let color: Color?
 
-    public init(value: NoteheadValue, filled: Bool? = nil, parentheses: Bool? = nil, font: Font = Font(), color: Color? = nil) {
+    public init(_ value: NoteheadValue, filled: Bool? = nil, parentheses: Bool? = nil, font: Font = Font(), color: Color? = nil) {
         self.value = value
         self.filled = filled
         self.parentheses = parentheses

--- a/Sources/MusicXML/Complex Types/OtherAppearance.swift
+++ b/Sources/MusicXML/Complex Types/OtherAppearance.swift
@@ -12,7 +12,7 @@ public struct OtherAppearance {
     public let value: String
     public let type: String
 
-    public init(value: String, type: String) {
+    public init(_ value: String, type: String) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/OtherDirection.swift
+++ b/Sources/MusicXML/Complex Types/OtherDirection.swift
@@ -13,7 +13,7 @@ public struct OtherDirection {
     public let printObject: Bool?
     public let printStyleAlign: PrintStyleAlign?
 
-    public init(value: String, printObject: Bool? = nil, printStyleAlign: PrintStyleAlign? = nil) {
+    public init(_ value: String, printObject: Bool? = nil, printStyleAlign: PrintStyleAlign? = nil) {
         self.value = value
         self.printObject = printObject
         self.printStyleAlign = printStyleAlign

--- a/Sources/MusicXML/Complex Types/OtherNotation.swift
+++ b/Sources/MusicXML/Complex Types/OtherNotation.swift
@@ -17,7 +17,7 @@ public struct OtherNotation {
     public let printStyle: PrintStyle?
     public let placement: AboveBelow?
 
-    public init(value: String, type: StartStopSingle, number: Int? = nil, printObject: Bool? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
+    public init(_ value: String, type: StartStopSingle, number: Int? = nil, printObject: Bool? = nil, printStyle: PrintStyle? = nil, placement: AboveBelow? = nil) {
         self.value = value
         self.type = type
         self.number = number

--- a/Sources/MusicXML/Complex Types/OtherPlay.swift
+++ b/Sources/MusicXML/Complex Types/OtherPlay.swift
@@ -11,7 +11,7 @@ public struct OtherPlay {
     public let value: String
     public let type: String
 
-    public init(value: String, type: String) {
+    public init(_ value: String, type: String) {
         self.value = value
         self.type = type
     }

--- a/Sources/MusicXML/Complex Types/PartSymbol.swift
+++ b/Sources/MusicXML/Complex Types/PartSymbol.swift
@@ -18,7 +18,7 @@ public struct PartSymbol {
     let position: Position
     let color: Color
 
-    public init(value: GroupSymbolValue, kind: Kind, topStaff: Int, bottomStaff: Int, position: Position, color: Color) {
+    public init(_ value: GroupSymbolValue, kind: Kind, topStaff: Int, bottomStaff: Int, position: Position, color: Color) {
         self.value = value
         self.kind = kind
         self.topStaff = topStaff

--- a/Sources/MusicXML/Complex Types/PerMinute.swift
+++ b/Sources/MusicXML/Complex Types/PerMinute.swift
@@ -13,7 +13,7 @@ public struct PerMinute {
     public let value: String
     public let font: Font?
 
-    public init(value: String, font: Font? = nil) {
+    public init(_ value: String, font: Font? = nil) {
         self.value = value
         self.font = font
     }

--- a/Sources/MusicXML/Complex Types/PrincipleVoice.swift
+++ b/Sources/MusicXML/Complex Types/PrincipleVoice.swift
@@ -15,7 +15,7 @@ public struct PrincipleVoice {
     public let symbol: PrincipleVoiceSymbol
     public let printStyleAlign: PrintStyleAlign?
 
-    public init(value: String, type: StartStop, symbol: PrincipleVoiceSymbol, printStyleAlign: PrintStyleAlign? = nil) {
+    public init(_ value: String, type: StartStop, symbol: PrincipleVoiceSymbol, printStyleAlign: PrintStyleAlign? = nil) {
         self.value = value
         self.type = type
         self.symbol = symbol

--- a/Sources/MusicXML/Complex Types/Rights.swift
+++ b/Sources/MusicXML/Complex Types/Rights.swift
@@ -23,11 +23,6 @@ public struct Rights {
         self.value = value
         self.type = type
     }
-
-    public init(value: String, type: String? = nil) {
-        self.value = value
-        self.type = type
-    }
 }
 
 extension Rights: Equatable { }

--- a/Sources/MusicXML/Complex Types/Slide.swift
+++ b/Sources/MusicXML/Complex Types/Slide.swift
@@ -19,7 +19,7 @@ public struct Slide {
     public let font: Font
     public let bendSound: BendSound
 
-    public init(value: String? = nil, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting = DashedFormatting(), printStyle: PrintStyle = PrintStyle(), font: Font = Font(), bendSound: BendSound = BendSound()) {
+    public init(_ value: String? = nil, type: StartStop, number: Int? = nil, lineType: LineType? = nil, dashedFormatting: DashedFormatting = DashedFormatting(), printStyle: PrintStyle = PrintStyle(), font: Font = Font(), bendSound: BendSound = BendSound()) {
         self.value = value
         self.type = type
         self.number = number

--- a/Sources/MusicXML/Complex Types/TextFontColor.swift
+++ b/Sources/MusicXML/Complex Types/TextFontColor.swift
@@ -16,7 +16,7 @@ public struct TextFontColor {
     public let letterSpacing: NumberOrNormal?
     public let dir: TextDirection?
 
-    public init(value: String, font: Font? = nil, color: Color? = nil, textDecoration: TextDecoration? = nil, textRotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, dir: TextDirection? = nil) {
+    public init(_ value: String, font: Font? = nil, color: Color? = nil, textDecoration: TextDecoration? = nil, textRotation: Double? = nil, letterSpacing: NumberOrNormal? = nil, dir: TextDirection? = nil) {
         self.value = value
         self.font = font
         self.color = color

--- a/Sources/MusicXML/Complex Types/TupletNumber.swift
+++ b/Sources/MusicXML/Complex Types/TupletNumber.swift
@@ -11,7 +11,7 @@ public struct TupletNumber {
     public let font: Font?
     public let color: Color?
 
-    public init(value: Int, font: Font? = nil, color: Color? = nil) {
+    public init(_ value: Int, font: Font? = nil, color: Color? = nil) {
         self.value = value
         self.font = font
         self.color = color

--- a/Sources/MusicXML/Complex Types/TupletType.swift
+++ b/Sources/MusicXML/Complex Types/TupletType.swift
@@ -12,7 +12,7 @@ public struct TupletType {
     public let font: Font?
     public let color: Color?
 
-    public init(value: NoteTypeValue, font: Font? = nil, color: Color? = nil) {
+    public init(_ value: NoteTypeValue, font: Font? = nil, color: Color? = nil) {
         self.value = value
         self.font = font
         self.color = color

--- a/Sources/MusicXML/Simple Types/AccordionMiddle.swift
+++ b/Sources/MusicXML/Simple Types/AccordionMiddle.swift
@@ -7,6 +7,10 @@
 
 public struct AccordionMiddle {
     public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
 }
 
 extension AccordionMiddle: Equatable {}
@@ -28,6 +32,6 @@ extension AccordionMiddle: Codable {
 
 extension AccordionMiddle: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
-        self.init(value: value)
+        self.init(value)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AccidentalTests.swift
@@ -24,7 +24,7 @@ class AccidentalTests: XCTestCase {
         let xml = """
         <accidental-mark placement="above">double-sharp</accidental-mark>
         """
-        let expected = AccidentalMark(value: .doubleSharp, placement: .above)
+        let expected = AccidentalMark(.doubleSharp, placement: .above)
         try assertDecoded(xml, equals: expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
@@ -33,9 +33,7 @@ class DirectionTests: XCTestCase {
                         kind: .regular(
                             Metronome.Regular(
                                 beatUnit: .quarter,
-                                relation: .perMinute(
-                                    PerMinute(value: "90")
-                                )
+                                relation: .perMinute(PerMinute("90"))
                             )
                         )
                     )

--- a/Tests/MusicXMLTests/Complex Types/IdentificationTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/IdentificationTests.swift
@@ -23,7 +23,7 @@ class IdentificationTests: XCTestCase {
         let expected = Identification(
             miscellaneous: Miscellaneous(
                 fields: [
-                    MiscellaneousField(name: "description", value: "Here is some text."),
+                    MiscellaneousField("Here is some text.", name: "description"),
                 ]
             )
         )

--- a/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
@@ -18,7 +18,7 @@ class MeasureStyleTests: XCTestCase {
         </measure-style>
         """
         let decoded = try XMLDecoder().decode(MeasureStyle.self, from: xml.data(using: .utf8)!)
-        let expected = MeasureStyle(kind: .multipleRest(MultipleRest(value: 2)))
+        let expected = MeasureStyle(kind: .multipleRest(MultipleRest(2)))
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -25,9 +25,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    relation: .perMinute(
-                        PerMinute(value: "90")
-                    )
+                    relation: .perMinute(PerMinute("90"))
                 )
             )
         )
@@ -50,9 +48,7 @@ class MetronomeTests: XCTestCase {
                 Metronome.Regular(
                     beatUnit: .quarter,
                     beatUnitDot: [Empty()],
-                    relation: .perMinute(
-                        PerMinute(value: "77")
-                    )
+                    relation: .perMinute(PerMinute("77"))
                 )
             )
         )

--- a/Tests/MusicXMLTests/Complex Types/MiscellaneousTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MiscellaneousTests.swift
@@ -24,11 +24,10 @@ class MiscellaneousTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Miscellaneous.self, from: xml.data(using: .utf8)!)
         let expected = Miscellaneous(
             fields: [
-                MiscellaneousField(
-                    name: "description",
-                    value: """
+                MiscellaneousField("""
                     All pitches from G to c\'\'\'\' in\n      ascending steps; First without accidentals, then with a sharp and then\n      with a flat accidental, then with explicit natural accidentals.\n      Double alterations and cautionary accidentals\n      are tested at the end.
-                    """
+                    """,
+                    name: "description"
                 )
             ]
         )
@@ -38,9 +37,9 @@ class MiscellaneousTests: XCTestCase {
     func testMiscellaneousRoundTrip() throws {
         let misc = Miscellaneous(
             fields: [
-                MiscellaneousField(name: "one", value: "1"),
-                MiscellaneousField(name: "two", value: "2"),
-                MiscellaneousField(name: "three", value: "3"),
+                MiscellaneousField("1", name: "one"),
+                MiscellaneousField("2", name: "two"),
+                MiscellaneousField("3", name: "three"),
             ]
         )
         try testRoundTrip(misc)

--- a/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NotationsTests.swift
@@ -40,7 +40,7 @@ class NotationsTests: XCTestCase {
         </notations>
         """
         try assertDecoded(xml,
-            equals: Notations([.fermata(Fermata(value: .normal))])
+            equals: Notations([.fermata(Fermata(.normal))])
         )
     }
 
@@ -70,8 +70,8 @@ class NotationsTests: XCTestCase {
             .ornaments(
                 Ornaments([.turn(HorizontalTurn())],
                     accidentalMarks: [
-                        AccidentalMark(value: .sharp, placement: .above),
-                        AccidentalMark(value: .threeQuartersFlat, placement: .above),
+                        AccidentalMark(.sharp, placement: .above),
+                        AccidentalMark(.threeQuartersFlat, placement: .above),
                     ]
                 )
             )
@@ -108,7 +108,7 @@ class NotationsTests: XCTestCase {
         """
         try assertDecoded(xml,
             equals: Notations([
-                .accidentalMark(AccidentalMark(value: .doubleSharp, placement: .above))
+                .accidentalMark(AccidentalMark(.doubleSharp, placement: .above))
             ])
         )
     }
@@ -169,7 +169,7 @@ class NotationsTests: XCTestCase {
         </notations>
         """
         try assertDecoded(xml,
-            equals: Notations([.fermata(Fermata(value: .normal, type: .upright))])
+            equals: Notations([.fermata(Fermata(.normal, type: .upright))])
         )
     }
 

--- a/Tests/MusicXMLTests/Complex Types/NoteTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/NoteTests.swift
@@ -157,8 +157,8 @@ class NoteTests: XCTestCase {
             type: .sixteenth,
             stem: .down,
             beams: [
-                Beam(value: .begin, number: .one),
-                Beam(value: .begin, number: .two)
+                Beam(.begin, number: .one),
+                Beam(.begin, number: .two)
             ]
         )
         XCTAssertEqual(decoded, expected)
@@ -226,7 +226,7 @@ class NoteTests: XCTestCase {
             type: .eighth,
             stem: Stem(.down, position: Position(defaultY: -70)),
             beams: [
-                Beam(value: .begin, number: .one)
+                Beam(.begin, number: .one)
             ]
         )
         XCTAssertEqual(decoded, expected)
@@ -253,7 +253,7 @@ class NoteTests: XCTestCase {
             isChord: true,
             voice: "1",
             type: .quarter,
-            notehead: Notehead(value: .normal, parentheses: true)
+            notehead: Notehead(.normal, parentheses: true)
         )
         XCTAssertEqual(decoded, expected)
     }

--- a/Tests/MusicXMLTests/Complex Types/OrnamentsTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/OrnamentsTests.swift
@@ -21,8 +21,8 @@ class OrnamentsTests: XCTestCase {
         let decoded = try XMLDecoder().decode(Ornaments.self, from: xml.data(using: .utf8)!)
         let expected = Ornaments([.turn(HorizontalTurn())],
             accidentalMarks: [
-                AccidentalMark(value: .sharp, placement: .above),
-                AccidentalMark(value: .threeQuartersFlat, placement: .above),
+                AccidentalMark(.sharp, placement: .above),
+                AccidentalMark(.threeQuartersFlat, placement: .above),
             ]
         )
 

--- a/Tests/MusicXMLTests/Complex Types/PartListTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartListTests.swift
@@ -46,8 +46,8 @@ class PartListTests: XCTestCase {
                 PartGroup(
                     type: .start,
                     number: 1,
-                    symbol: GroupSymbol(value: .bracket),
-                    barline: GroupBarline(value: .yes)
+                    symbol: GroupSymbol(.bracket),
+                    barline: GroupBarline(.yes)
                 )
             ),
             .part(ScorePart(id: "P1", name: "Part 1")),

--- a/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/PartNameTests.swift
@@ -29,7 +29,7 @@ class PartNameTests: XCTestCase {
         let decoded = try XMLDecoder(trimValueWhitespaces: false).decode(NameDisplay.self, from: xml.data(using: .utf8)!)
         let expected = NameDisplay(texts: [
             .displayText("Trumpet in B"),
-            .accidentalText(AccidentalText(value: .flat)),
+            .accidentalText(AccidentalText(.flat)),
             .displayText(" 1")
         ])
         XCTAssertEqual(decoded, expected)


### PR DESCRIPTION
This PR more-systematically updates types which have a `value`.

This `value` is always first, and is always has no attribute labels in initializers.

Resolves #103.