### PR TITLE
[WIP / Experimental / Do Not Merge] Use @dynamicMemberLookup

### DIFF
--- a/Sources/MusicXML/Complex Types/Accidental.swift
+++ b/Sources/MusicXML/Complex Types/Accidental.swift
@@ -9,6 +9,7 @@
 /// are indicated by attributes. Values for these attributes are "no" if not present. Specific
 /// graphic display such as parentheses, brackets, and size are controlled by the level-display
 /// attribute group.
+@dynamicMemberLookup
 public struct Accidental {
 
     // MARK: - Instance Properties
@@ -45,6 +46,11 @@ public struct Accidental {
         self.bracket = bracket
         self.size = size
         self.printStyle = printStyle
+    }
+
+    /// - Returns: A `PrintStyle` attribute.
+    public subscript <T> (dynamicMember keyPath: KeyPath<PrintStyle, T>) -> T {
+        return printStyle[keyPath: keyPath]
     }
 }
 

--- a/Sources/MusicXML/Complex Types/MeasureAttributes.swift
+++ b/Sources/MusicXML/Complex Types/MeasureAttributes.swift
@@ -1,0 +1,30 @@
+//
+//  MeasureAttributes.swift
+//  MusicXML
+//
+//  Created by James Bean on 10/15/19.
+//
+
+/// The attributes which are shared between the `Timewise` and `Partwise` forms of `Measure`.
+public struct MeasureAttributes {
+    public let number: String
+    public let text: String?
+    public let implicit: Bool?
+    public let nonControlling: Bool?
+    public let width: Tenths?
+    public let optionalUniqueID: Int?
+}
+
+extension MeasureAttributes: Equatable { }
+extension MeasureAttributes: Hashable { }
+
+extension MeasureAttributes: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case number
+        case text
+        case implicit
+        case nonControlling = "non-controlling"
+        case width
+        case optionalUniqueID = "optional-unique-id"
+    }
+}

--- a/Sources/MusicXML/Complex Types/MeasureAttributes.swift
+++ b/Sources/MusicXML/Complex Types/MeasureAttributes.swift
@@ -18,7 +18,7 @@ public struct MeasureAttributes {
 extension MeasureAttributes: Equatable { }
 extension MeasureAttributes: Hashable { }
 
-extension MeasureAttributes: Decodable {
+extension MeasureAttributes: Codable {
     private enum CodingKeys: String, CodingKey {
         case number
         case text

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
@@ -24,7 +24,48 @@ extension Partwise {
     // MARK: - Instance Methods
 
     public func toTimewise() -> Timewise {
-        fatalError()
+        // FIXME: Consider sharing this across `Partwise.Measure` and `Timewise.Measure` under the
+        // hood.
+        struct MeasureAttributes: Equatable, Hashable {
+            let number: String
+            let text: String?
+            let implicit: Bool?
+            let nonControlling: Bool?
+            let width: Tenths?
+            let optionalUniqueID: Int?
+        }
+        var partsByMeasureAttributes: [MeasureAttributes: [Timewise.Part]] = [:]
+        for partwisePart in parts {
+            for partwiseMeasure in partwisePart.measures {
+                let attrs = MeasureAttributes(
+                    number: partwiseMeasure.number,
+                    text: partwiseMeasure.text,
+                    implicit: partwiseMeasure.implicit,
+                    nonControlling: partwiseMeasure.nonControlling,
+                    width: partwiseMeasure.width,
+                    optionalUniqueID: partwiseMeasure.optionalUniqueID
+                )
+                let timewisePart = Timewise.Part(
+                    id: partwisePart.id,
+                    musicData: partwiseMeasure.musicData
+                )
+                partsByMeasureAttributes[attrs, default: []].append(timewisePart)
+            }
+        }
+        return Timewise(
+            header: header,
+            measures: partsByMeasureAttributes.map { attrs, parts in
+                Timewise.Measure(
+                    number: attrs.number,
+                    text: attrs.text,
+                    implicit: attrs.implicit,
+                    nonControlling: attrs.nonControlling,
+                    width: attrs.width,
+                    optionalUniqueID: attrs.optionalUniqueID,
+                    parts: parts
+                )
+            }
+        )
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
@@ -25,16 +25,6 @@ extension Partwise {
 
     /// - Returns: A `Timewise` representation of this `Partwise` traversal.
     public func toTimewise() -> Timewise {
-        // FIXME: Consider sharing this across `Partwise.Measure` and `Timewise.Measure` under the
-        // hood.
-        struct MeasureAttributes: Equatable, Hashable {
-            let number: String
-            let text: String?
-            let implicit: Bool?
-            let nonControlling: Bool?
-            let width: Tenths?
-            let optionalUniqueID: Int?
-        }
         var partsByMeasureAttributes: [MeasureAttributes: [Timewise.Part]] = [:]
         for partwisePart in parts {
             for partwiseMeasure in partwisePart.measures {

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
@@ -19,6 +19,15 @@ public struct Partwise {
     }
 }
 
+extension Partwise {
+
+    // MARK: - Instance Methods
+
+    public func toTimewise() -> Timewise {
+        fatalError()
+    }
+}
+
 extension Partwise: Equatable { }
 
 extension Partwise: Codable {

--- a/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
+++ b/Sources/MusicXML/Complex Types/Partwise/Partwise.swift
@@ -23,6 +23,7 @@ extension Partwise {
 
     // MARK: - Instance Methods
 
+    /// - Returns: A `Timewise` representation of this `Partwise` traversal.
     public func toTimewise() -> Timewise {
         // FIXME: Consider sharing this across `Partwise.Measure` and `Timewise.Measure` under the
         // hood.

--- a/Sources/MusicXML/Complex Types/PrintStyle.swift
+++ b/Sources/MusicXML/Complex Types/PrintStyle.swift
@@ -7,6 +7,7 @@
 
 /// The print-style attribute group collects the most popular combination of printing attributes:
 /// position, font, and color.
+@dynamicMemberLookup
 public struct PrintStyle {
     public let position: Position
     public let font: Font
@@ -16,6 +17,11 @@ public struct PrintStyle {
         self.position = position
         self.font = font
         self.color = color
+    }
+
+    /// - Returns: A `Position` attribute.
+    public subscript <T> (dynamicMember keyPath: KeyPath<Position, T>) -> T {
+        return position[keyPath: keyPath]
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.Measure.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.Measure.swift
@@ -50,14 +50,21 @@ extension Timewise {
     //     width %tenths; #IMPLIED
     //     %optional-unique-id;
     // >
+    @dynamicMemberLookup
     public struct Measure: Equatable {
-        let number: String
-        let text: String?
-        let implicit: Bool?
-        let nonControlling: Bool?
-        let width: Tenths?
-        let optionalUniqueID: Int?
-        let parts: [Part]
+
+        // MARK: Instance Properties
+
+        // MARK: Attributes
+
+        private let attributes: MeasureAttributes
+
+        // MARK: Elements
+
+        public let parts: [Part]
+
+
+        // MARK: - Initializers
 
         public init(
             number: String,
@@ -68,13 +75,20 @@ extension Timewise {
             optionalUniqueID: Int? = nil,
             parts: [Part]
         ) {
-            self.number = number
-            self.text = text
-            self.implicit = implicit
-            self.nonControlling = nonControlling
-            self.width = width
-            self.optionalUniqueID = optionalUniqueID
+            self.attributes = MeasureAttributes(
+                number: number,
+                text: text,
+                implicit: implicit,
+                nonControlling: nonControlling,
+                width: width,
+                optionalUniqueID: optionalUniqueID
+            )
             self.parts = parts
+        }
+
+        /// - Returns: A measure attribute.
+        public subscript <T> (dynamicMember keyPath: KeyPath<MeasureAttributes, T>) -> T {
+            return attributes[keyPath: keyPath]
         }
     }
 }
@@ -83,13 +97,17 @@ extension Timewise.Measure: Codable {
 
     // MARK: - Codable
 
-    enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey {
         case parts = "part"
-        case number
-        case text
-        case implicit
-        case nonControlling = "non-controlling"
-        case width
-        case optionalUniqueID = "optional-unique-id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.attributes = try MeasureAttributes(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.parts = try container.decode([Timewise.Part].self, forKey: .parts)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        fatalError()
     }
 }

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
@@ -24,8 +24,24 @@ extension Timewise {
 
     // MARK: - Instance Methods
 
+    /// - Returns: A `Partwise` representation of this `Timewise` traversal.
     public func toPartwise() -> Partwise {
-        fatalError()
+        var measuresByPartID: [String: [Partwise.Measure]] = [:]
+        for timewiseMeasure in measures {
+            for timewisePart in timewiseMeasure.parts {
+                let partwiseMeasure = Partwise.Measure(
+                    number: timewiseMeasure.number,
+                    text: timewiseMeasure.text,
+                    implicit: timewiseMeasure.implicit,
+                    nonControlling: timewiseMeasure.nonControlling,
+                    width: timewiseMeasure.width,
+                    optionalUniqueID: timewiseMeasure.optionalUniqueID,
+                    musicData: timewisePart.musicData
+                )
+                measuresByPartID[timewisePart.id, default: []].append(partwiseMeasure)
+            }
+        }
+        return Partwise(header: header, parts: measuresByPartID.map(Partwise.Part.init))
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
+++ b/Sources/MusicXML/Complex Types/Timewise/Timewise.swift
@@ -20,6 +20,15 @@ public struct Timewise {
     }
 }
 
+extension Timewise {
+
+    // MARK: - Instance Methods
+
+    public func toPartwise() -> Partwise {
+        fatalError()
+    }
+}
+
 extension Timewise: Equatable { }
 
 extension Timewise: Codable {

--- a/Sources/MusicXML/Simple Types/Tenths.swift
+++ b/Sources/MusicXML/Simple Types/Tenths.swift
@@ -10,6 +10,8 @@ public struct Tenths {
 }
 
 extension Tenths: Equatable { }
+extension Tenths: Hashable { }
+
 extension Tenths: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
@@ -31,3 +33,5 @@ extension Tenths: ExpressibleByIntegerLiteral {
         self.value = Double(value)
     }
 }
+
+

--- a/Tests/MusicXMLTests/TraversalConversionTests.swift
+++ b/Tests/MusicXMLTests/TraversalConversionTests.swift
@@ -1,0 +1,50 @@
+//
+//  TraversalConversionTests.swift
+//  MusicXMLTests
+//
+//  Created by James Bean on 10/15/19.
+//
+
+import XCTest
+import MusicXML
+
+class TraversalConversionTests: XCTestCase {
+
+    func testHelloWorldRoundTrip() throws {
+        // Shared values
+        let note = Note(pitch: Pitch(step: .c, octave: 4), duration: 4, type: .whole)
+        let attributes = Attributes(
+            divisions: 1,
+            keys: [Key(fifths: 0)],
+            times: [Time(4,4)],
+            clefs: [Clef(sign: .g, line: 2)]
+        )
+        let header = Header(
+            partList: [
+                .part(ScorePart(id: "P1", name: "Music"))
+            ]
+        )
+        // Create `Partwise` traversal
+        let partwiseMeasure = Partwise.Measure(
+            number: "1",
+            musicData: [
+                .attributes(attributes),
+                .note(note)
+            ]
+        )
+        let partwisePart = Partwise.Part(id: "P1", measures: [partwiseMeasure])
+        let partwise = Partwise(header: header, parts: [partwisePart])
+        // Create `Timewise` traversal
+        let timewisePart = Timewise.Part(
+            id: "P1",
+            musicData: [
+                .attributes(attributes),
+                .note(note)
+            ]
+        )
+        let timewiseMeasure = Timewise.Measure(number: "1", parts: [timewisePart])
+        let timewise = Timewise(header: header, measures: [timewiseMeasure])
+        XCTAssertEqual(timewise.toPartwise().toTimewise(), timewise)
+        XCTAssertEqual(partwise.toTimewise().toPartwise(), partwise)
+    }
+}

--- a/Tests/MusicXMLTests/TraversalConversionTests.swift
+++ b/Tests/MusicXMLTests/TraversalConversionTests.swift
@@ -44,6 +44,8 @@ class TraversalConversionTests: XCTestCase {
         )
         let timewiseMeasure = Timewise.Measure(number: "1", parts: [timewisePart])
         let timewise = Timewise(header: header, measures: [timewiseMeasure])
+        XCTAssertEqual(timewise.toPartwise(), partwise)
+        XCTAssertEqual(partwise.toTimewise(), timewise)
         XCTAssertEqual(timewise.toPartwise().toTimewise(), timewise)
         XCTAssertEqual(partwise.toTimewise().toPartwise(), partwise)
     }


### PR DESCRIPTION
This PR tries out the usage of `KeyPath`-based `@dynamicMemberLookup` for percolating the attributes of certain attribute groups (`PrintStyle`, `PrintStyleAlign`, `Position`, etc.) up to the top-level of a structure which holds onto such an attribute group.

In the first applicable commit (268557a), we can use it like this:

```Swift
let sharp = Accidental.sharp
let defaultX = sharp.defaultX
```

This reaches down two levels: `Accidental` -> `PrintStyle` -> `Position`. I chose not to expose the properties of `Font` because the `font.` prefix contextualizes the members' names (`.style`, etc.).

@DJBen, @bwetherfield, let me know if this seems dangerous or superfluous to you.

(I will get rid of the commit trash shortly.)