### PR TITLE
Turn off trimValueWhitespaces in XMLDecoder by default

### DIFF
--- a/Sources/MusicXML/Decoding/Decoding.swift
+++ b/Sources/MusicXML/Decoding/Decoding.swift
@@ -29,6 +29,6 @@ extension MusicXML {
 
     /// Creates a `MusicXML` model from the given MusicXML-formatted `data`.
     public init(data: Data) throws {
-        self.score = try XMLDecoder().decode(Score.self, from: data)
+        self.score = try XMLDecoder(trimValueWhitespaces: false).decode(Score.self, from: data)
     }
 }


### PR DESCRIPTION
I am not sure about the benefit added by trimming value whitespaces; on the contrary, having the option turned on by default introduces potential bugs like https://github.com/MaxDesiatov/XMLCoder/pull/142

Let's turn it off, and later we may choose to turn it back on if sufficient value can be added and bugs can be fixed on XMLCoder's end.

What do you think?