### PR TITLE
Remove public usage of Empty

### DIFF
--- a/Sources/MusicXML/Complex Types/AccordionRegistration.swift
+++ b/Sources/MusicXML/Complex Types/AccordionRegistration.swift
@@ -20,17 +20,17 @@ public struct AccordionRegistration {
 
     // MARK: Elements
 
-    public let high: Empty?
+    public let high: Bool
     public let middle: AccordionMiddle?
-    public let low: Empty?
+    public let low: Bool
 
     // MARK: - Initializers
 
     public init(
         printStyleAlign: PrintStyleAlign = PrintStyleAlign(),
-        accordionHigh: Empty? = nil,
+        accordionHigh: Bool = false,
         accordionMiddle: AccordionMiddle? = nil,
-        accordionLow: Empty? = nil
+        accordionLow: Bool = false
     ) {
         self.printStyleAlign = printStyleAlign
         self.high = accordionHigh
@@ -52,10 +52,10 @@ extension AccordionRegistration: Codable {
     }
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
         self.printStyleAlign = try PrintStyleAlign(from: decoder)
-        self.high = try container.decodeIfPresent(Empty.self, forKey: .high)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.high = container.contains(.high)
+        self.low = container.contains(.low)
         self.middle = try container.decodeIfPresent(AccordionMiddle.self, forKey: .middle)
-        self.low = try container.decodeIfPresent(Empty.self, forKey: .low)
     }
 }

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -49,7 +49,7 @@ extension Metronome {
     public struct Regular {
         public enum Relation {
             case perMinute(PerMinute)
-            case beatUnit(NoteTypeValue, [Empty]? = nil)
+            case beatUnit(NoteTypeValue, dots: Int)
         }
         
         /// The beat-unit element indicates the graphical note type to use in a metronome mark.
@@ -92,8 +92,10 @@ extension Metronome {
                     self.relation = .perMinute(perMinute)
                 case let .beatUnit(beatUnit):
                     componentsCopy.removeFirst()
-                    let beatUnitDotInRelation = componentsCopy.prefix(while: isBeatUnitDot).map { _ in Empty() }
-                    self.relation = .beatUnit(beatUnit, beatUnitDotInRelation.isEmpty ? nil : beatUnitDotInRelation)
+                    let beatUnitDotInRelation = componentsCopy
+                        .prefix(while: isBeatUnitDot)
+                        .map { _ in Empty() }
+                    self.relation = .beatUnit(beatUnit, dots: beatUnitDotInRelation.count)
                 default:
                     throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires per-minute or beat-unit to be present"))
             }

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -45,10 +45,10 @@ extension Metronome {
         public let beatUnit: NoteTypeValue
         /// The beat-unit-dot element is used to specify any augmentation dots for a metronome mark
         /// note.
-        public let beatUnitDot: [Empty]?
+        public let beatUnitDot: Int
         public let relation: Relation
 
-        public init(beatUnit: NoteTypeValue, beatUnitDot: [Empty]? = nil, relation: Relation) {
+        public init(beatUnit: NoteTypeValue, beatUnitDot: Int = 0, relation: Relation) {
             self.beatUnit = beatUnit
             self.beatUnitDot = beatUnitDot
             self.relation = relation
@@ -70,7 +70,7 @@ extension Metronome {
             }
 
             let beatUnitDot = componentsCopy.prefix(while: isBeatUnitDot).map { _ in Empty() }
-            self.beatUnitDot = beatUnitDot.isEmpty ? nil : beatUnitDot
+            self.beatUnitDot = beatUnitDot.count
             componentsCopy = [MetronomeRegularComponent](componentsCopy.drop(while: isBeatUnitDot))
             guard let firstRelationComponent = componentsCopy.first else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires per-minute or beat-unit to be present"))

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -45,12 +45,12 @@ extension Metronome {
         public let beatUnit: NoteTypeValue
         /// The beat-unit-dot element is used to specify any augmentation dots for a metronome mark
         /// note.
-        public let beatUnitDot: Int
+        public let beatUnitDots: Int
         public let relation: Relation
 
-        public init(beatUnit: NoteTypeValue, beatUnitDot: Int = 0, relation: Relation) {
+        public init(beatUnit: NoteTypeValue, beatUnitDots: Int = 0, relation: Relation) {
             self.beatUnit = beatUnit
-            self.beatUnitDot = beatUnitDot
+            self.beatUnitDots = beatUnitDots
             self.relation = relation
         }
 
@@ -70,7 +70,7 @@ extension Metronome {
             }
 
             let beatUnitDot = componentsCopy.prefix(while: isBeatUnitDot).map { _ in Empty() }
-            self.beatUnitDot = beatUnitDot.count
+            self.beatUnitDots = beatUnitDot.count
             componentsCopy = [MetronomeRegularComponent](componentsCopy.drop(while: isBeatUnitDot))
             guard let firstRelationComponent = componentsCopy.first else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires per-minute or beat-unit to be present"))

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -13,6 +13,12 @@ import XMLCoder
 /// relationships, such as swing tempo marks where two eighths are equated to a quarter note /
 /// eighth note triplet.
 public struct Metronome {
+
+    // MARK: - Instance Properties
+
+    // MARK: Kind
+    public let kind: Kind
+
     // MARK: - Attributes
     public let position: Position
     public let printStyleAlign: PrintStyleAlign?
@@ -21,15 +27,20 @@ public struct Metronome {
     /// its value is no if not specified.
     public let parentheses: Bool?
 
-    // MARK: - Elements
-    public let kind: Kind
+    // MARK: - Initializers
 
-    public init(position: Position = Position(), printStyleAlign: PrintStyleAlign? = nil, justify: Justify? = nil, parentheses: Bool? = nil, kind: Kind) {
+    public init(
+        kind: Kind,
+        position: Position = Position(),
+        printStyleAlign: PrintStyleAlign? = nil,
+        justify: Justify? = nil,
+        parentheses: Bool? = nil
+    ) {
+        self.kind = kind
         self.position = position
         self.printStyleAlign = printStyleAlign
         self.justify = justify
         self.parentheses = parentheses
-        self.kind = kind
     }
 }
 

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -49,7 +49,7 @@ extension Metronome {
     public struct Regular {
         public enum Relation {
             case perMinute(PerMinute)
-            case beatUnit(NoteTypeValue, dots: Int)
+            case beatUnit(NoteTypeValue, dotCount: Int)
         }
         
         /// The beat-unit element indicates the graphical note type to use in a metronome mark.
@@ -95,7 +95,7 @@ extension Metronome {
                     let beatUnitDotInRelation = componentsCopy
                         .prefix(while: isBeatUnitDot)
                         .map { _ in Empty() }
-                    self.relation = .beatUnit(beatUnit, dots: beatUnitDotInRelation.count)
+                    self.relation = .beatUnit(beatUnit, dotCount: beatUnitDotInRelation.count)
                 default:
                     throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires per-minute or beat-unit to be present"))
             }

--- a/Sources/MusicXML/Complex Types/Metronome.swift
+++ b/Sources/MusicXML/Complex Types/Metronome.swift
@@ -56,12 +56,12 @@ extension Metronome {
         public let beatUnit: NoteTypeValue
         /// The beat-unit-dot element is used to specify any augmentation dots for a metronome mark
         /// note.
-        public let beatUnitDots: Int
+        public let beatUnitDotCount: Int
         public let relation: Relation
 
-        public init(beatUnit: NoteTypeValue, beatUnitDots: Int = 0, relation: Relation) {
+        public init(beatUnit: NoteTypeValue, beatUnitDotCount: Int = 0, relation: Relation) {
             self.beatUnit = beatUnit
-            self.beatUnitDots = beatUnitDots
+            self.beatUnitDotCount = beatUnitDotCount
             self.relation = relation
         }
 
@@ -81,7 +81,7 @@ extension Metronome {
             }
 
             let beatUnitDot = componentsCopy.prefix(while: isBeatUnitDot).map { _ in Empty() }
-            self.beatUnitDots = beatUnitDot.count
+            self.beatUnitDotCount = beatUnitDot.count
             componentsCopy = [MetronomeRegularComponent](componentsCopy.drop(while: isBeatUnitDot))
             guard let firstRelationComponent = componentsCopy.first else {
                 throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Requires per-minute or beat-unit to be present"))

--- a/Sources/MusicXML/Complex Types/MetronomeNote.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeNote.swift
@@ -7,18 +7,42 @@
 
 /// The metronome-note type defines the appearance of a note within a metric relationship mark.
 public struct MetronomeNote {
+
+    // MARK: - Instance Properties
+
     public let metronomeType: NoteTypeValue
-    public let metronomeDot: [Empty]
-    public let metronomeBeam: [MetronomeBeam]
+    public let metronomeDotCount: Int
+    public let metronomeBeams: [MetronomeBeam]
     public let metronomeTuplet: MetronomeTuplet?
 
-    public init(metronomeType: NoteTypeValue, metronomeDot: [Empty], metronomeBeam: [MetronomeBeam], metronomeTuplet: MetronomeTuplet? = nil) {
+    // MARK: - Initializers
+
+    public init(
+        metronomeType: NoteTypeValue,
+        metronomeDotCount: Int = 0,
+        metronomeBeams: [MetronomeBeam] = [],
+        metronomeTuplet: MetronomeTuplet? = nil
+    ) {
         self.metronomeType = metronomeType
-        self.metronomeDot = metronomeDot
-        self.metronomeBeam = metronomeBeam
+        self.metronomeDotCount = metronomeDotCount
+        self.metronomeBeams = metronomeBeams
         self.metronomeTuplet = metronomeTuplet
     }
 }
 
 extension MetronomeNote: Equatable { }
-extension MetronomeNote: Codable { }
+extension MetronomeNote: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case metronomeType = "metronome-type"
+        case metronomeDotCount = "metronome-dot"
+        case metronomeBeams = "metronome-beam"
+        case metronomeTuplet = "metronome-tuplet"
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.metronomeType = try container.decode(NoteTypeValue.self, forKey: .metronomeType)
+        self.metronomeDotCount = try container.decode([Empty].self, forKey: .metronomeDotCount).count
+        self.metronomeBeams = try container.decode([MetronomeBeam].self, forKey: .metronomeBeams)
+        self.metronomeTuplet = try container.decodeIfPresent(MetronomeTuplet.self, forKey: .metronomeTuplet)
+    }
+}

--- a/Sources/MusicXML/Complex Types/Percussion.swift
+++ b/Sources/MusicXML/Complex Types/Percussion.swift
@@ -34,7 +34,7 @@ extension Percussion {
         case pitched(Pitched)
         case stick(Stick)
         case stickLocation(StickLocation)
-        case timpani(Empty)
+        case timpani
         case wood(Wood)
     }
 }
@@ -75,8 +75,8 @@ extension Percussion.Kind: Codable {
             try container.encode(value, forKey: .stick)
         case let .stickLocation(value):
             try container.encode(value, forKey: .stickLocation)
-        case let .timpani(value):
-            try container.encode(value, forKey: .timpani)
+        case .timpani:
+            try container.encode(Empty(), forKey: .timpani)
         case let .wood(value):
             try container.encode(value, forKey: .wood)
         }
@@ -107,7 +107,7 @@ extension Percussion.Kind: Codable {
         } else if container.contains(.stickLocation) {
             self = .stickLocation(try decode(.stickLocation))
         } else if container.contains(.timpani) {
-            self = .timpani(try decode(.timpani))
+            self = .timpani
         } else if container.contains(.wood) {
             self = .wood(try decode(.wood))
         } else {

--- a/Sources/MusicXML/Complex Types/TimeModification.swift
+++ b/Sources/MusicXML/Complex Types/TimeModification.swift
@@ -22,9 +22,14 @@ public struct TimeModification {
     /// normal-notes type (e.g. eighth) is specified in the normal-type and normal-dot elements.
     public var normalType: NoteTypeValue?
     /// The normal-dot element is used to specify dotted normal tuplet types.
-    public var normalDot: [Empty]?
+    public var normalDot: Int
 
-    public init(actualNotes: Int, normalNotes: Int, normalType: NoteTypeValue? = nil, normalDot: [Empty]? = nil) {
+    public init(
+        actualNotes: Int,
+        normalNotes: Int,
+        normalType: NoteTypeValue? = nil,
+        normalDot: Int = 0
+    ) {
         self.actualNotes = actualNotes
         self.normalNotes = normalNotes
         self.normalType = normalType
@@ -39,5 +44,12 @@ extension TimeModification: Codable {
         case normalNotes = "normal-notes"
         case normalType = "normal-type"
         case normalDot = "normal-dot"
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.actualNotes = try container.decode(Int.self, forKey: .actualNotes)
+        self.normalNotes = try container.decode(Int.self, forKey: .normalNotes)
+        self.normalType = try container.decodeIfPresent(NoteTypeValue.self, forKey: .normalType)
+        self.normalDot = try container.decode([Empty].self, forKey: .normalDot).count
     }
 }

--- a/Sources/MusicXML/Complex Types/TimeModification.swift
+++ b/Sources/MusicXML/Complex Types/TimeModification.swift
@@ -22,18 +22,18 @@ public struct TimeModification {
     /// normal-notes type (e.g. eighth) is specified in the normal-type and normal-dot elements.
     public var normalType: NoteTypeValue?
     /// The normal-dot element is used to specify dotted normal tuplet types.
-    public var normalDot: Int
+    public var normalDotCount: Int
 
     public init(
         actualNotes: Int,
         normalNotes: Int,
         normalType: NoteTypeValue? = nil,
-        normalDot: Int = 0
+        normalDotCount: Int = 0
     ) {
         self.actualNotes = actualNotes
         self.normalNotes = normalNotes
         self.normalType = normalType
-        self.normalDot = normalDot
+        self.normalDotCount = normalDotCount
     }
 }
 
@@ -43,13 +43,13 @@ extension TimeModification: Codable {
         case actualNotes = "actual-notes"
         case normalNotes = "normal-notes"
         case normalType = "normal-type"
-        case normalDot = "normal-dot"
+        case normalDotCount = "normal-dot"
     }
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.actualNotes = try container.decode(Int.self, forKey: .actualNotes)
         self.normalNotes = try container.decode(Int.self, forKey: .normalNotes)
         self.normalType = try container.decodeIfPresent(NoteTypeValue.self, forKey: .normalType)
-        self.normalDot = try container.decode([Empty].self, forKey: .normalDot).count
+        self.normalDotCount = try container.decode([Empty].self, forKey: .normalDotCount).count
     }
 }

--- a/Sources/MusicXML/Complex Types/TupletPortion.swift
+++ b/Sources/MusicXML/Complex Types/TupletPortion.swift
@@ -12,12 +12,12 @@
 public struct TupletPortion {
     public let tupletNumber: TupletNumber?
     public let tupletType: TupletType?
-    public let tupletDot: [TupletDot]
+    public let tupletDots: [TupletDot]
 
-    public init(tupletNumber: TupletNumber? = nil, tupletType: TupletType? = nil, tupletDot: [TupletDot]) {
+    public init(tupletNumber: TupletNumber? = nil, tupletType: TupletType? = nil, tupletDots: [TupletDot]) {
         self.tupletNumber = tupletNumber
         self.tupletType = tupletType
-        self.tupletDot = tupletDot
+        self.tupletDots = tupletDots
     }
 }
 

--- a/Sources/MusicXML/Decoding/Empty.swift
+++ b/Sources/MusicXML/Decoding/Empty.swift
@@ -5,9 +5,8 @@
 //  Created by James Bean on 5/15/19.
 //
 
-public struct Empty {
-    public init() {
-    }
+internal struct Empty {
+    internal init() { }
  }
 
 extension Empty: Equatable { }

--- a/Sources/MusicXML/Decoding/Empty.swift
+++ b/Sources/MusicXML/Decoding/Empty.swift
@@ -6,7 +6,7 @@
 //
 
 internal struct Empty {
-    internal init() { }
+    init() { }
  }
 
 extension Empty: Equatable { }

--- a/Tests/MusicXMLTests/Complex Types/AccordionRegistrationTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/AccordionRegistrationTests.swift
@@ -18,7 +18,7 @@ class AccordionRegistrationTests: XCTestCase {
         </accordion-registration>
         """
         let decoded = try XMLDecoder().decode(AccordionRegistration.self, from: xml.data(using: .utf8)!)
-        let expected = AccordionRegistration(accordionHigh: Empty(), accordionMiddle: 2)
+        let expected = AccordionRegistration(accordionHigh: true, accordionMiddle: 2)
         XCTAssertEqual(decoded, expected)
     }
 }

--- a/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/DirectionTests.swift
@@ -28,14 +28,14 @@ class DirectionTests: XCTestCase {
             [
                 .metronome(
                     Metronome(
-                        position: Position(defaultX: -25.96, relativeY: 20.00),
-                        parentheses: false,
                         kind: .regular(
                             Metronome.Regular(
                                 beatUnit: .quarter,
                                 relation: .perMinute(PerMinute("90"))
                             )
-                        )
+                        ),
+                        position: Position(defaultX: -25.96, relativeY: 20.00),
+                        parentheses: false
                     )
                 )
             ],

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -47,7 +47,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDot: 1,
+                    beatUnitDots: 1,
                     relation: .perMinute(PerMinute("77"))
                 )
             )
@@ -70,7 +70,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDot: 1,
+                    beatUnitDots: 1,
                     relation: .beatUnit(.half, [Empty()])
                 )
             )

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -71,7 +71,7 @@ class MetronomeTests: XCTestCase {
                 Metronome.Regular(
                     beatUnit: .quarter,
                     beatUnitDots: 1,
-                    relation: .beatUnit(.half, [Empty()])
+                    relation: .beatUnit(.half, dots: 1)
                 )
             )
         )
@@ -92,7 +92,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .long,
-                    relation: .beatUnit(.thirysecond, [Empty()])
+                    relation: .beatUnit(.thirysecond, dots: 1)
                 )
             ),
             parentheses: true

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -71,7 +71,7 @@ class MetronomeTests: XCTestCase {
                 Metronome.Regular(
                     beatUnit: .quarter,
                     beatUnitDots: 1,
-                    relation: .beatUnit(.half, dots: 1)
+                    relation: .beatUnit(.half, dotCount: 1)
                 )
             )
         )
@@ -92,7 +92,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .long,
-                    relation: .beatUnit(.thirysecond, dots: 1)
+                    relation: .beatUnit(.thirysecond, dotCount: 1)
                 )
             ),
             parentheses: true

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -46,7 +46,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDots: 1,
+                    beatUnitDotCount: 1,
                     relation: .perMinute(PerMinute("77"))
                 )
             ),
@@ -70,7 +70,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDots: 1,
+                    beatUnitDotCount: 1,
                     relation: .beatUnit(.half, dotCount: 1)
                 )
             )

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -20,14 +20,14 @@ class MetronomeTests: XCTestCase {
 
         let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
         let expected: Metronome = Metronome(
-            position: Position(defaultX: -25.96, relativeY: 20.00),
-            parentheses: false,
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
                     relation: .perMinute(PerMinute("90"))
                 )
-            )
+            ),
+            position: Position(defaultX: -25.96, relativeY: 20.00),
+            parentheses: false
         )
         XCTAssertEqual(decoded, expected)
     }
@@ -43,14 +43,14 @@ class MetronomeTests: XCTestCase {
 
         let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
         let expected: Metronome = Metronome(
-            parentheses: true,
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
                     beatUnitDots: 1,
                     relation: .perMinute(PerMinute("77"))
                 )
-            )
+            ),
+            parentheses: true
         )
         XCTAssertEqual(decoded, expected)
     }
@@ -89,13 +89,13 @@ class MetronomeTests: XCTestCase {
 
         let decoded = try XMLDecoder().decode(Metronome.self, from: xml.data(using: .utf8)!)
         let expected: Metronome = Metronome(
-            parentheses: true,
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .long,
                     relation: .beatUnit(.thirysecond, [Empty()])
                 )
-            )
+            ),
+            parentheses: true
         )
         XCTAssertEqual(decoded, expected)
     }

--- a/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MetronomeTests.swift
@@ -47,7 +47,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDot: [Empty()],
+                    beatUnitDot: 1,
                     relation: .perMinute(PerMinute("77"))
                 )
             )
@@ -70,7 +70,7 @@ class MetronomeTests: XCTestCase {
             kind: .regular(
                 Metronome.Regular(
                     beatUnit: .quarter,
-                    beatUnitDot: [Empty()],
+                    beatUnitDot: 1,
                     relation: .beatUnit(.half, [Empty()])
                 )
             )


### PR DESCRIPTION
This PR removes the usage of the `Empty` type in the public API of `MusicXML`. It is still used for the (de|en)coding process under the hood.

Along the way, some names are standardized.

This addresses #178.