### PR TITLE
Use tagged version of XMLCoder

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -7,7 +7,7 @@
         "state": {
           "branch": null,
           "revision": "51c791f9523ce78efd742067fb32f29214d3082a",
-          "version": null
+          "version": "0.8.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jsbean/XMLCoder", .revision("51c791f9523ce78efd742067fb32f29214d3082a")),
+        .package(url: "https://github.com/jsbean/XMLCoder", from: "0.8.1"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
Neither the `branch` nor `revision` pointers to `XMLCoder` were satisfying the SwiftPM dependency resolver downstream.

This is working for me, now.