### PR TITLE
Update value coding key dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "XMLCoder",
-        "repositoryURL": "https://github.com/jsbean/XMLCoder",
+        "repositoryURL": "https://github.com/bwetherfield/XMLCoder",
         "state": {
-          "branch": null,
-          "revision": "51c791f9523ce78efd742067fb32f29214d3082a",
-          "version": "0.8.1"
+          "branch": "value-to-empty-string",
+          "revision": "b5d16df218a43ad680d1e5ee9fbeb2fc760695ce",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "XMLCoder",
-        "repositoryURL": "https://github.com/jsbean/XMLCoder",
+        "repositoryURL": "https://github.com/bwetherfield/XMLCoder",
         "state": {
-          "branch": null,
-          "revision": "51c791f9523ce78efd742067fb32f29214d3082a",
-          "version": "0.8.1"
+          "branch": "value-coding-key-empty",
+          "revision": "f35a28a5093dc7952116422f3bff05fcb08e8324",
+          "version": null
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "XMLCoder",
-        "repositoryURL": "https://github.com/bwetherfield/XMLCoder",
+        "repositoryURL": "https://github.com/jsbean/XMLCoder",
         "state": {
-          "branch": "value-to-empty-string",
-          "revision": "b5d16df218a43ad680d1e5ee9fbeb2fc760695ce",
-          "version": null
+          "branch": null,
+          "revision": "51c791f9523ce78efd742067fb32f29214d3082a",
+          "version": "0.8.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jsbean/XMLCoder", from: "0.8.1"),
+        .package(url: "https://github.com/bwetherfield/XMLCoder", .branch("value-coding-key-empty")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/bwetherfield/XMLCoder", .branch("value-to-empty-string")),
+        .package(url: "https://github.com/jsbean/XMLCoder", from: "0.8.1"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["MusicXML"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/jsbean/XMLCoder", from: "0.8.1"),
+        .package(url: "https://github.com/bwetherfield/XMLCoder", .branch("value-to-empty-string")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [

--- a/Sources/MusicXML/Complex Types/Beam.swift
+++ b/Sources/MusicXML/Complex Types/Beam.swift
@@ -29,7 +29,6 @@ public struct Beam {
 
 extension Beam: Equatable { }
 extension Beam: Codable {
-    // sourcery:inline:Beam.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case number
         case repeater
@@ -37,5 +36,4 @@ extension Beam: Codable {
         case color
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/Beam.swift
+++ b/Sources/MusicXML/Complex Types/Beam.swift
@@ -28,4 +28,14 @@ public struct Beam {
 }
 
 extension Beam: Equatable { }
-extension Beam: Codable { }
+extension Beam: Codable {
+    // sourcery:inline:Beam.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case number
+        case repeater
+        case fan
+        case color
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/Beater.swift
+++ b/Sources/MusicXML/Complex Types/Beater.swift
@@ -16,4 +16,9 @@ public struct Beater {
 }
 
 extension Beater: Equatable { }
-extension Beater: Codable { }
+extension Beater: Codable {
+    enum CodingKeys: String, CodingKey {
+        case tip
+        case value = ""
+    }
+}

--- a/Sources/MusicXML/Complex Types/BreathMark.swift
+++ b/Sources/MusicXML/Complex Types/BreathMark.swift
@@ -47,6 +47,7 @@ extension BreathMark: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.placement = try container.decodeIfPresent(AboveBelow.self, forKey: .placement)
         // Decode value
-        self.value = try container.decodeIfPresent(BreathMarkValue.self, forKey: .value) ?? .comma
+        let breathMarkValue = try container.decode(BreathMarkValue.self, forKey: .value)
+        self.value = breathMarkValue == .default ? .comma : breathMarkValue
     }
 }

--- a/Sources/MusicXML/Complex Types/Distance.swift
+++ b/Sources/MusicXML/Complex Types/Distance.swift
@@ -17,4 +17,9 @@ public struct Distance {
 }
 
 extension Distance: Equatable { }
-extension Distance: Codable { }
+extension Distance: Codable {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+}

--- a/Sources/MusicXML/Complex Types/Feature.swift
+++ b/Sources/MusicXML/Complex Types/Feature.swift
@@ -19,4 +19,9 @@ public struct Feature {
 }
 
 extension Feature: Equatable { }
-extension Feature: Codable { }
+extension Feature: Codable {
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+}

--- a/Sources/MusicXML/Complex Types/FirstFret.swift
+++ b/Sources/MusicXML/Complex Types/FirstFret.swift
@@ -20,4 +20,10 @@ public struct FirstFret {
 }
 
 extension FirstFret: Equatable { }
-extension FirstFret: Codable { }
+extension FirstFret: Codable {
+    enum CodingKeys: String, CodingKey {
+        case text
+        case location
+        case value = ""
+    }
+}

--- a/Sources/MusicXML/Complex Types/Glissando.swift
+++ b/Sources/MusicXML/Complex Types/Glissando.swift
@@ -29,7 +29,6 @@ public struct Glissando {
 
 extension Glissando: Equatable { }
 extension Glissando: Codable {
-    // sourcery:inline:Glissando.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case number
@@ -38,5 +37,4 @@ extension Glissando: Codable {
         case printStyle
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/Glissando.swift
+++ b/Sources/MusicXML/Complex Types/Glissando.swift
@@ -28,4 +28,15 @@ public struct Glissando {
 }
 
 extension Glissando: Equatable { }
-extension Glissando: Codable { }
+extension Glissando: Codable {
+    // sourcery:inline:Glissando.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case number
+        case lineType
+        case dashedFormatting
+        case printStyle
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/GroupName.swift
+++ b/Sources/MusicXML/Complex Types/GroupName.swift
@@ -22,11 +22,9 @@ public struct GroupName {
 
 extension GroupName: Equatable { }
 extension GroupName: Codable {
-    // sourcery:inline:GroupName.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case printStyle
         case justify
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/GroupName.swift
+++ b/Sources/MusicXML/Complex Types/GroupName.swift
@@ -21,4 +21,12 @@ public struct GroupName {
 }
 
 extension GroupName: Equatable { }
-extension GroupName: Codable { }
+extension GroupName: Codable {
+    // sourcery:inline:GroupName.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case printStyle
+        case justify
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
+++ b/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
@@ -28,7 +28,6 @@ public struct HammerOnPullOff {
 
 extension HammerOnPullOff: Equatable { }
 extension HammerOnPullOff: Codable {
-    // sourcery:inline:HammerOnPullOff.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case number
@@ -36,5 +35,4 @@ extension HammerOnPullOff: Codable {
         case placement
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
+++ b/Sources/MusicXML/Complex Types/HammerOnPullOff.swift
@@ -27,4 +27,14 @@ public struct HammerOnPullOff {
 }
 
 extension HammerOnPullOff: Equatable { }
-extension HammerOnPullOff: Codable { }
+extension HammerOnPullOff: Codable {
+    // sourcery:inline:HammerOnPullOff.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case number
+        case printStyle
+        case placement
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/Handbell.swift
+++ b/Sources/MusicXML/Complex Types/Handbell.swift
@@ -20,4 +20,12 @@ public struct Handbell {
 }
 
 extension Handbell: Equatable { }
-extension Handbell: Codable { }
+extension Handbell: Codable {
+    // sourcery:inline:Handbell.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case printStyle
+        case placement
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/Handbell.swift
+++ b/Sources/MusicXML/Complex Types/Handbell.swift
@@ -21,11 +21,9 @@ public struct Handbell {
 
 extension Handbell: Equatable { }
 extension Handbell: Codable {
-    // sourcery:inline:Handbell.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case printStyle
         case placement
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/HoleClosed.swift
+++ b/Sources/MusicXML/Complex Types/HoleClosed.swift
@@ -19,4 +19,11 @@ public struct HoleClosed {
 }
 
 extension HoleClosed: Equatable { }
-extension HoleClosed: Codable { }
+extension HoleClosed: Codable {
+    // sourcery:inline:HoleClosed.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case location
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/HoleClosed.swift
+++ b/Sources/MusicXML/Complex Types/HoleClosed.swift
@@ -20,10 +20,8 @@ public struct HoleClosed {
 
 extension HoleClosed: Equatable { }
 extension HoleClosed: Codable {
-    // sourcery:inline:HoleClosed.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case location
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/KeyOctave.swift
+++ b/Sources/MusicXML/Complex Types/KeyOctave.swift
@@ -38,6 +38,14 @@ extension KeyOctave {
 
 extension KeyOctave: Equatable { }
 extension KeyOctave: Codable {
+    // sourcery:inline:KeyOctave.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case number
+        case cancel
+        case value = ""
+    }
+    // sourcery:end
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.value = try container.decode(Int.self, forKey: .value)

--- a/Sources/MusicXML/Complex Types/KeyOctave.swift
+++ b/Sources/MusicXML/Complex Types/KeyOctave.swift
@@ -38,13 +38,11 @@ extension KeyOctave {
 
 extension KeyOctave: Equatable { }
 extension KeyOctave: Codable {
-    // sourcery:inline:KeyOctave.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case number
         case cancel
         case value = ""
     }
-    // sourcery:end
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/MusicXML/Complex Types/LineWidth.swift
+++ b/Sources/MusicXML/Complex Types/LineWidth.swift
@@ -18,4 +18,11 @@ public struct LineWidth {
 }
 
 extension LineWidth: Equatable { }
-extension LineWidth: Codable { }
+extension LineWidth: Codable {
+    // sourcery:inline:LineWidth.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/LineWidth.swift
+++ b/Sources/MusicXML/Complex Types/LineWidth.swift
@@ -19,10 +19,8 @@ public struct LineWidth {
 
 extension LineWidth: Equatable { }
 extension LineWidth: Codable {
-    // sourcery:inline:LineWidth.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/MetronomeBeam.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeBeam.swift
@@ -19,10 +19,8 @@ public struct MetronomeBeam {
 
 extension MetronomeBeam: Equatable { }
 extension MetronomeBeam: Codable {
-    // sourcery:inline:MetronomeBeam.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case number
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/MetronomeBeam.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeBeam.swift
@@ -18,4 +18,11 @@ public struct MetronomeBeam {
 }
 
 extension MetronomeBeam: Equatable { }
-extension MetronomeBeam: Codable { }
+extension MetronomeBeam: Codable {
+    // sourcery:inline:MetronomeBeam.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case number
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
@@ -23,12 +23,10 @@ public struct MetronomeTuplet {
 
 extension MetronomeTuplet: Equatable { }
 extension MetronomeTuplet: Codable {
-    // sourcery:inline:MetronomeTuplet.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case bracket
         case showNumber
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
+++ b/Sources/MusicXML/Complex Types/MetronomeTuplet.swift
@@ -22,4 +22,13 @@ public struct MetronomeTuplet {
 }
 
 extension MetronomeTuplet: Equatable { }
-extension MetronomeTuplet: Codable { }
+extension MetronomeTuplet: Codable {
+    // sourcery:inline:MetronomeTuplet.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case bracket
+        case showNumber
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/Mordent.swift
+++ b/Sources/MusicXML/Complex Types/Mordent.swift
@@ -27,4 +27,13 @@ public struct Mordent {
 }
 
 extension Mordent: Equatable { }
-extension Mordent: Codable { }
+extension Mordent: Codable {
+    // sourcery:inline:Mordent.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case long
+        case approach
+        case departure
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/Mordent.swift
+++ b/Sources/MusicXML/Complex Types/Mordent.swift
@@ -28,12 +28,10 @@ public struct Mordent {
 
 extension Mordent: Equatable { }
 extension Mordent: Codable {
-    // sourcery:inline:Mordent.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case long
         case approach
         case departure
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/MultipleRest.swift
+++ b/Sources/MusicXML/Complex Types/MultipleRest.swift
@@ -29,4 +29,11 @@ public struct MultipleRest {
 }
 
 extension MultipleRest: Equatable { }
-extension MultipleRest: Codable { }
+extension MultipleRest: Codable {
+    // sourcery:inline:MultipleRest.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case useSymbols
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/MultipleRest.swift
+++ b/Sources/MusicXML/Complex Types/MultipleRest.swift
@@ -30,10 +30,8 @@ public struct MultipleRest {
 
 extension MultipleRest: Equatable { }
 extension MultipleRest: Codable {
-    // sourcery:inline:MultipleRest.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case useSymbols
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/NoteSize.swift
+++ b/Sources/MusicXML/Complex Types/NoteSize.swift
@@ -23,4 +23,11 @@ public struct NoteSize {
 }
 
 extension NoteSize: Equatable { }
-extension NoteSize: Codable { }
+extension NoteSize: Codable {
+    // sourcery:inline:NoteSize.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/NoteSize.swift
+++ b/Sources/MusicXML/Complex Types/NoteSize.swift
@@ -24,10 +24,8 @@ public struct NoteSize {
 
 extension NoteSize: Equatable { }
 extension NoteSize: Codable {
-    // sourcery:inline:NoteSize.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/NoteType.swift
+++ b/Sources/MusicXML/Complex Types/NoteType.swift
@@ -42,4 +42,11 @@ extension NoteType {
 }
 
 extension NoteType: Equatable { }
-extension NoteType: Codable { }
+extension NoteType: Codable {
+    // sourcery:inline:NoteType.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case size
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/NoteType.swift
+++ b/Sources/MusicXML/Complex Types/NoteType.swift
@@ -43,10 +43,8 @@ extension NoteType {
 
 extension NoteType: Equatable { }
 extension NoteType: Codable {
-    // sourcery:inline:NoteType.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case size
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/OtherAppearance.swift
+++ b/Sources/MusicXML/Complex Types/OtherAppearance.swift
@@ -20,10 +20,8 @@ public struct OtherAppearance {
 
 extension OtherAppearance: Equatable { }
 extension OtherAppearance: Codable {
-    // sourcery:inline:OtherAppearance.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/OtherAppearance.swift
+++ b/Sources/MusicXML/Complex Types/OtherAppearance.swift
@@ -19,4 +19,11 @@ public struct OtherAppearance {
 }
 
 extension OtherAppearance: Equatable { }
-extension OtherAppearance: Codable { }
+extension OtherAppearance: Codable {
+    // sourcery:inline:OtherAppearance.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/OtherDirection.swift
+++ b/Sources/MusicXML/Complex Types/OtherDirection.swift
@@ -21,4 +21,12 @@ public struct OtherDirection {
 }
 
 extension OtherDirection: Equatable { }
-extension OtherDirection: Codable { }
+extension OtherDirection: Codable {
+    // sourcery:inline:OtherDirection.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case printObject
+        case printStyleAlign
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/OtherDirection.swift
+++ b/Sources/MusicXML/Complex Types/OtherDirection.swift
@@ -22,11 +22,9 @@ public struct OtherDirection {
 
 extension OtherDirection: Equatable { }
 extension OtherDirection: Codable {
-    // sourcery:inline:OtherDirection.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case printObject
         case printStyleAlign
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/OtherNotation.swift
+++ b/Sources/MusicXML/Complex Types/OtherNotation.swift
@@ -29,7 +29,6 @@ public struct OtherNotation {
 
 extension OtherNotation: Equatable { }
 extension OtherNotation: Codable {
-    // sourcery:inline:OtherNotation.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case number
@@ -38,5 +37,4 @@ extension OtherNotation: Codable {
         case placement
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/OtherNotation.swift
+++ b/Sources/MusicXML/Complex Types/OtherNotation.swift
@@ -28,4 +28,15 @@ public struct OtherNotation {
 }
 
 extension OtherNotation: Equatable { }
-extension OtherNotation: Codable { }
+extension OtherNotation: Codable {
+    // sourcery:inline:OtherNotation.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case number
+        case printObject
+        case printStyle
+        case placement
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/OtherPlay.swift
+++ b/Sources/MusicXML/Complex Types/OtherPlay.swift
@@ -19,10 +19,8 @@ public struct OtherPlay {
 
 extension OtherPlay: Equatable { }
 extension OtherPlay: Codable {
-    // sourcery:inline:OtherPlay.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/OtherPlay.swift
+++ b/Sources/MusicXML/Complex Types/OtherPlay.swift
@@ -18,4 +18,11 @@ public struct OtherPlay {
 }
 
 extension OtherPlay: Equatable { }
-extension OtherPlay: Codable { }
+extension OtherPlay: Codable {
+    // sourcery:inline:OtherPlay.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/PartSymbol.swift
+++ b/Sources/MusicXML/Complex Types/PartSymbol.swift
@@ -30,7 +30,6 @@ public struct PartSymbol {
 
 extension PartSymbol: Equatable { }
 extension PartSymbol: Codable {
-    // sourcery:inline:PartSymbol.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case kind
         case topStaff
@@ -39,5 +38,4 @@ extension PartSymbol: Codable {
         case color
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/PartSymbol.swift
+++ b/Sources/MusicXML/Complex Types/PartSymbol.swift
@@ -29,4 +29,15 @@ public struct PartSymbol {
 }
 
 extension PartSymbol: Equatable { }
-extension PartSymbol: Codable { }
+extension PartSymbol: Codable {
+    // sourcery:inline:PartSymbol.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case topStaff
+        case bottomStaff
+        case position
+        case color
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/PerMinute.swift
+++ b/Sources/MusicXML/Complex Types/PerMinute.swift
@@ -20,4 +20,11 @@ public struct PerMinute {
 }
 
 extension PerMinute: Equatable { }
-extension PerMinute: Codable { }
+extension PerMinute: Codable {
+    // sourcery:inline:PerMinute.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case font
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/PerMinute.swift
+++ b/Sources/MusicXML/Complex Types/PerMinute.swift
@@ -21,10 +21,8 @@ public struct PerMinute {
 
 extension PerMinute: Equatable { }
 extension PerMinute: Codable {
-    // sourcery:inline:PerMinute.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case font
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/PlacementText.swift
+++ b/Sources/MusicXML/Complex Types/PlacementText.swift
@@ -41,14 +41,12 @@ public struct PlacementText {
 
 extension PlacementText: Equatable { }
 extension PlacementText: Codable {
-    // sourcery:inline:PlacementText.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case placement
         case position
         case printStyle
         case value = ""
     }
-    // sourcery:end
 
     public init(from decoder: Decoder) throws {
         // Decode attribute groups

--- a/Sources/MusicXML/Complex Types/PlacementText.swift
+++ b/Sources/MusicXML/Complex Types/PlacementText.swift
@@ -41,6 +41,14 @@ public struct PlacementText {
 
 extension PlacementText: Equatable { }
 extension PlacementText: Codable {
+    // sourcery:inline:PlacementText.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case placement
+        case position
+        case printStyle
+        case value = ""
+    }
+    // sourcery:end
 
     public init(from decoder: Decoder) throws {
         // Decode attribute groups

--- a/Sources/MusicXML/Complex Types/PrincipleVoice.swift
+++ b/Sources/MusicXML/Complex Types/PrincipleVoice.swift
@@ -25,12 +25,10 @@ public struct PrincipleVoice {
 
 extension PrincipleVoice: Equatable { }
 extension PrincipleVoice: Codable {
-    // sourcery:inline:PrincipleVoice.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case type
         case symbol
         case printStyleAlign
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/PrincipleVoice.swift
+++ b/Sources/MusicXML/Complex Types/PrincipleVoice.swift
@@ -24,4 +24,13 @@ public struct PrincipleVoice {
 }
 
 extension PrincipleVoice: Equatable { }
-extension PrincipleVoice: Codable { }
+extension PrincipleVoice: Codable {
+    // sourcery:inline:PrincipleVoice.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case type
+        case symbol
+        case printStyleAlign
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/TextElementData.swift
+++ b/Sources/MusicXML/Complex Types/TextElementData.swift
@@ -50,7 +50,6 @@ public struct TextElementData {
 
 extension TextElementData: Equatable { }
 extension TextElementData: Codable {
-    // sourcery:inline:TextElementData.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case font
         case textDecoration
@@ -60,7 +59,6 @@ extension TextElementData: Codable {
         case direction
         case value = ""
     }
-    // sourcery:end
 }
 
 extension TextElementData: ExpressibleByStringLiteral {

--- a/Sources/MusicXML/Complex Types/TextElementData.swift
+++ b/Sources/MusicXML/Complex Types/TextElementData.swift
@@ -49,7 +49,19 @@ public struct TextElementData {
 }
 
 extension TextElementData: Equatable { }
-extension TextElementData: Codable { }
+extension TextElementData: Codable {
+    // sourcery:inline:TextElementData.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case font
+        case textDecoration
+        case color
+        case textRotation
+        case letterSpacing
+        case direction
+        case value = ""
+    }
+    // sourcery:end
+}
 
 extension TextElementData: ExpressibleByStringLiteral {
 

--- a/Sources/MusicXML/Complex Types/TextFontColor.swift
+++ b/Sources/MusicXML/Complex Types/TextFontColor.swift
@@ -28,4 +28,16 @@ public struct TextFontColor {
 }
 
 extension TextFontColor: Equatable { }
-extension TextFontColor: Codable { }
+extension TextFontColor: Codable {
+    // sourcery:inline:TextFontColor.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case font
+        case color
+        case textDecoration
+        case textRotation
+        case letterSpacing
+        case dir
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/TextFontColor.swift
+++ b/Sources/MusicXML/Complex Types/TextFontColor.swift
@@ -29,7 +29,6 @@ public struct TextFontColor {
 
 extension TextFontColor: Equatable { }
 extension TextFontColor: Codable {
-    // sourcery:inline:TextFontColor.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case font
         case color
@@ -39,5 +38,4 @@ extension TextFontColor: Codable {
         case dir
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/TupletNumber.swift
+++ b/Sources/MusicXML/Complex Types/TupletNumber.swift
@@ -19,4 +19,12 @@ public struct TupletNumber {
 }
 
 extension TupletNumber: Equatable { }
-extension TupletNumber: Codable { }
+extension TupletNumber: Codable {
+    // sourcery:inline:TupletNumber.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case font
+        case color
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Complex Types/TupletNumber.swift
+++ b/Sources/MusicXML/Complex Types/TupletNumber.swift
@@ -20,11 +20,9 @@ public struct TupletNumber {
 
 extension TupletNumber: Equatable { }
 extension TupletNumber: Codable {
-    // sourcery:inline:TupletNumber.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case font
         case color
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/TupletType.swift
+++ b/Sources/MusicXML/Complex Types/TupletType.swift
@@ -21,11 +21,9 @@ public struct TupletType {
 
 extension TupletType: Equatable { }
 extension TupletType: Codable {
-    // sourcery:inline:TupletType.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case font
         case color
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Complex Types/TupletType.swift
+++ b/Sources/MusicXML/Complex Types/TupletType.swift
@@ -20,4 +20,12 @@ public struct TupletType {
 }
 
 extension TupletType: Equatable { }
-extension TupletType: Codable { }
+extension TupletType: Codable {
+    // sourcery:inline:TupletType.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case font
+        case color
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Simple Types/AccordionMiddle.swift
+++ b/Sources/MusicXML/Simple Types/AccordionMiddle.swift
@@ -15,6 +15,12 @@ public struct AccordionMiddle {
 
 extension AccordionMiddle: Equatable {}
 extension AccordionMiddle: Codable {
+    // sourcery:inline:AccordionMiddle.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case value = ""
+    }
+    // sourcery:end
+    
     public func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)
     }

--- a/Sources/MusicXML/Simple Types/AccordionMiddle.swift
+++ b/Sources/MusicXML/Simple Types/AccordionMiddle.swift
@@ -15,11 +15,9 @@ public struct AccordionMiddle {
 
 extension AccordionMiddle: Equatable {}
 extension AccordionMiddle: Codable {
-    // sourcery:inline:AccordionMiddle.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case value = ""
     }
-    // sourcery:end
     
     public func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)

--- a/Sources/MusicXML/Simple Types/BreathMarkValue.swift
+++ b/Sources/MusicXML/Simple Types/BreathMarkValue.swift
@@ -9,6 +9,7 @@
 public enum BreathMarkValue: String {
     case comma
     case tick
+    case `default` = ""
 }
 
 extension BreathMarkValue: Equatable { }

--- a/Sources/MusicXML/Simple Types/EndingNumber.swift
+++ b/Sources/MusicXML/Simple Types/EndingNumber.swift
@@ -15,9 +15,7 @@ public struct EndingNumber {
 
 extension EndingNumber: Equatable { }
 extension EndingNumber: Codable {
-    // sourcery:inline:EndingNumber.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Simple Types/EndingNumber.swift
+++ b/Sources/MusicXML/Simple Types/EndingNumber.swift
@@ -14,4 +14,10 @@ public struct EndingNumber {
 }
 
 extension EndingNumber: Equatable { }
-extension EndingNumber: Codable { }
+extension EndingNumber: Codable {
+    // sourcery:inline:EndingNumber.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Simple Types/NonNegativeDecimal.swift
+++ b/Sources/MusicXML/Simple Types/NonNegativeDecimal.swift
@@ -10,4 +10,10 @@ public struct NonNegativeDecimal {
 }
 
 extension NonNegativeDecimal: Equatable { }
-extension NonNegativeDecimal: Codable { }
+extension NonNegativeDecimal: Codable {
+    // sourcery:inline:NonNegativeDecimal.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case value = ""
+    }
+    // sourcery:end
+}

--- a/Sources/MusicXML/Simple Types/NonNegativeDecimal.swift
+++ b/Sources/MusicXML/Simple Types/NonNegativeDecimal.swift
@@ -11,9 +11,7 @@ public struct NonNegativeDecimal {
 
 extension NonNegativeDecimal: Equatable { }
 extension NonNegativeDecimal: Codable {
-    // sourcery:inline:NonNegativeDecimal.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case value = ""
     }
-    // sourcery:end
 }

--- a/Sources/MusicXML/Simple Types/Tenths.swift
+++ b/Sources/MusicXML/Simple Types/Tenths.swift
@@ -13,6 +13,12 @@ extension Tenths: Equatable { }
 extension Tenths: Hashable { }
 
 extension Tenths: Codable {
+    // sourcery:inline:Tenths.ExplicitCodingKey
+    enum CodingKeys: String, CodingKey {
+        case value = ""
+    }
+    // sourcery:end
+    
     public func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)
     }

--- a/Sources/MusicXML/Simple Types/Tenths.swift
+++ b/Sources/MusicXML/Simple Types/Tenths.swift
@@ -13,11 +13,9 @@ extension Tenths: Equatable { }
 extension Tenths: Hashable { }
 
 extension Tenths: Codable {
-    // sourcery:inline:Tenths.ExplicitCodingKey
     enum CodingKeys: String, CodingKey {
         case value = ""
     }
-    // sourcery:end
     
     public func encode(to encoder: Encoder) throws {
         try value.encode(to: encoder)

--- a/Sources/MusicXML/Templates/ExplicitCodingKey.stencil
+++ b/Sources/MusicXML/Templates/ExplicitCodingKey.stencil
@@ -1,0 +1,15 @@
+{# A template to generate basic coding keys #}
+{# Example: $sourcery --sources Complex\ Types/Accidental.swift --templates Templates/ExplicitCodingKey.stencil --output Output/ #}
+{% for type in types.structs %}
+// sourcery:inline:{{ type.name }}.ExplicitCodingKey
+enum CodingKeys: String, CodingKey {
+{% for var in type.storedVariables where var.name != "value" %}
+    case {{ var.name }}
+{% endfor %}
+{% for var in type.storedVariables where var.name == "value" %}
+    case value = ""
+{% endfor %}
+}
+// sourcery:end
+
+{% endfor %}


### PR DESCRIPTION
Changing the use of special case `"value"` key to the special case `""` key as proposed in [this PR](https://github.com/MaxDesiatov/XMLCoder/pull/149) and implemented in [this active branch](https://github.com/bwetherfield/XMLCoder/tree/value-coding-key-empty).

The only meaningful change I have needed besides adding a lot of `case value = ""` lines (with the help of Sourcery), is found in [BreathMark.swift](https://github.com/dn-m/MusicXML/blob/eb696ae7fa1f2c9d914be5dcbf6787859f2a0f96/Sources/MusicXML/Complex%20Types/BreathMark.swift). I do think the implementation there now is probably as it should be now that an optional string type reads `<optionalString/>` as `""` rather than `nil`.