### PR TITLE
Using a data probing strategy, efficiently retrieve the top level tag to determine which top level parser to use

### DIFF
--- a/Sources/MusicXML/Complex Types/Score.swift
+++ b/Sources/MusicXML/Complex Types/Score.swift
@@ -50,10 +50,20 @@ extension Score: Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        do {
-            self = .partwise(try container.decode(Partwise.self))
-        } catch {
-            self = .timewise(try container.decode(Timewise.self))
+        if let codingKey = decoder.userInfo[CodingUserInfoKey(rawValue: Score.topLevelTagKey)!] as? CodingKeys {
+            switch codingKey {
+            case .partwise:
+                self = .partwise(try container.decode(Partwise.self))
+            case .timewise:
+                self = .timewise(try container.decode(Timewise.self))
+            }
+        } else {
+            // Fall back to try each top level tag
+            do {
+                self = .partwise(try container.decode(Partwise.self))
+            } catch {
+                self = .timewise(try container.decode(Timewise.self))
+            }
         }
     }
 }

--- a/Sources/MusicXML/Decoding/Decoding.swift
+++ b/Sources/MusicXML/Decoding/Decoding.swift
@@ -9,6 +9,7 @@ import Foundation
 import XMLCoder
 
 extension Score {
+    public static let topLevelTagKey = "topLevelTagKey"
 
     public enum Error: Swift.Error {
         case invalidMusicXMLString(Swift.String)
@@ -29,6 +30,65 @@ extension Score {
 
     /// Creates a `MusicXML` model from the given MusicXML-formatted `data`.
     public init(data: Data) throws {
-        self = try XMLDecoder(trimValueWhitespaces: false).decode(Score.self, from: data)
+        let decoder = XMLDecoder(trimValueWhitespaces: false)
+
+        if let topLevelTag = Score.probeTopLevelTag(data: data) {
+            decoder.userInfo[CodingUserInfoKey(rawValue: Score.topLevelTagKey)!] = topLevelTag
+        }
+
+        self = try decoder.decode(Score.self, from: data)
+    }
+
+    // A data probe that reads 64 bytes each pass to try to find the top level tag within the MusicXML
+    private static func probeTopLevelTag(data: Data) -> Score.CodingKeys? {
+        let input = InputStream(data: data)
+        input.open()
+
+        var data = Data()
+        let bufferSize = 64
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+
+        defer {
+            buffer.deallocate()
+            input.close()
+        }
+
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if (read == 0) {
+                return nil
+            }
+            data.append(buffer, count: read)
+
+            let docTypeProbe: String
+            if let probed = String(data: data, encoding: .utf8) {
+                docTypeProbe = probed
+            } else if let probed = String(data: data, encoding: .utf16) {
+                docTypeProbe = probed
+            } else {
+                return nil
+            }
+
+            if let tag = findTopLevelTag(pattern: #"<!DOCTYPE ((?:score-partwise|score-timewise))"#, in: docTypeProbe) {
+                return tag
+            } else if let tag = findTopLevelTag(pattern: #"<((?:score-partwise|score-timewise)) version="[\d.]+">"#, in: docTypeProbe) {
+                return tag
+            }
+        }
+        return nil
+    }
+
+    // Find top level tag provided with a pattern and a string, the pattern should contain exactly one capture group
+    private static func findTopLevelTag(pattern: String, in string: String) -> Score.CodingKeys? {
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let nsrange = NSRange(string.startIndex..<string.endIndex, in: string)
+            if let match = regex.firstMatch(in: string, options: [], range: nsrange), match.numberOfRanges == 2, let captureRange = Range(match.range(at: 1), in: string), let key = Score.CodingKeys(rawValue: String(string[captureRange])) {
+                return key
+            }
+            return nil
+        } catch {
+            return nil
+        }
     }
 }


### PR DESCRIPTION

- This change makes all the parsing errors in `partwise` documents MUCH more understandable because it will no longer be swallowed.
- This change also increases parsing speed for `timewise` documents because it will no longer attempt to parse it with `partwise` parser first.