### PR TITLE
Refactor assemble functionality for Key

### DIFF
--- a/Sources/MusicXML/Complex Types/Key.swift
+++ b/Sources/MusicXML/Complex Types/Key.swift
@@ -202,7 +202,7 @@ enum KeyComponent: Decodable {
     case keyAccidental(AccidentalValue)
 }
 
-fileprivate extension Decoder {
+private extension Decoder {
     func assemble(from components: [KeyComponent]) throws -> [Key.AlteredTone] {
         var alteredTones = [Key.AlteredTone]()
         var previousStep: Step?
@@ -220,7 +220,7 @@ fileprivate extension Decoder {
                         throw DecodingError.typeMismatch(
                             Key.self,
                             DecodingError.Context(
-                                codingPath: self.codingPath,
+                                codingPath: codingPath,
                                 debugDescription: "Two key-step values in a row in non-traditional key"
                             )
                         )
@@ -236,7 +236,7 @@ fileprivate extension Decoder {
                     throw DecodingError.typeMismatch(
                         Key.self,
                         DecodingError.Context(
-                            codingPath: self.codingPath,
+                            codingPath: codingPath,
                             debugDescription: "key-alter value not preceded by key-step value in non-traditional key"
                         )
                     )
@@ -252,7 +252,7 @@ fileprivate extension Decoder {
                     throw DecodingError.typeMismatch(
                         Key.self,
                         DecodingError.Context(
-                            codingPath: self.codingPath,
+                            codingPath: codingPath,
                             debugDescription: "key-accidental not preceded by key-step and key-alter in non-traditional key"
                         )
                     )
@@ -269,7 +269,7 @@ fileprivate extension Decoder {
             throw DecodingError.typeMismatch(
                 Key.self,
                 DecodingError.Context(
-                    codingPath: self.codingPath,
+                    codingPath: codingPath,
                     debugDescription: "Whole number of altered tones not represented in non-traditional key"
                 )
             )

--- a/Sources/MusicXML/Complex Types/Key.swift
+++ b/Sources/MusicXML/Complex Types/Key.swift
@@ -152,78 +152,7 @@ extension Key: Codable {
             )
         } catch {
             // Attempt to decode non-traditional `Key`.
-            var alteredTones = [AlteredTone]()
-            let components: [KeyComponent] = try decoder.collectArray()
-            var previousStep: Step?
-            var previousAlter: Double?
-            for component in components {
-                switch component {
-                case let .keyStep(step):
-                    if let unwrappedStep = previousStep {
-                        if let alter = previousAlter {
-                            alteredTones.append(AlteredTone(step: unwrappedStep, alter: alter))
-                            previousStep = step
-                            previousAlter = nil
-                        } else {
-                            // The previous value was also a key-step
-                            throw DecodingError.typeMismatch(
-                                Key.self,
-                                DecodingError.Context(
-                                    codingPath: decoder.codingPath,
-                                    debugDescription: "Two key-step values in a row in non-traditional key"
-                                )
-                            )
-                        }
-                    } else {
-                        previousStep = step
-                    }
-                case let .keyAlter(alter):
-                    if previousStep != nil {
-                        previousAlter = alter
-                    } else {
-                        // The preceding value was not a key-step
-                        throw DecodingError.typeMismatch(
-                            Key.self,
-                            DecodingError.Context(
-                                codingPath: decoder.codingPath,
-                                debugDescription: "key-alter value not preceded by key-step value in non-traditional key"
-                            )
-                        )
-                    }
-                case let .keyAccidental(accidental):
-                    if let step = previousStep, let alter = previousAlter {
-                        alteredTones.append(AlteredTone(step: step, alter: alter, accidental: accidental))
-                        // Reset
-                        previousStep = nil
-                        previousAlter = nil
-                    } else {
-                        // This accidental was not preceded by a key-step and a key-alter
-                        throw DecodingError.typeMismatch(
-                            Key.self,
-                            DecodingError.Context(
-                                codingPath: decoder.codingPath,
-                                debugDescription: "key-accidental not preceded by key-step and key-alter in non-traditional key"
-                            )
-                        )
-                    }
-                }
-            }
-            if let step = previousStep, let alter = previousAlter {
-                alteredTones.append(AlteredTone(step: step, alter: alter))
-                previousStep = nil
-                previousAlter = nil
-            }
-            guard previousStep == nil, previousAlter == nil else {
-                // Should not have leftover previous step or previous alter
-                throw DecodingError.typeMismatch(
-                    Key.self,
-                    DecodingError.Context(
-                        codingPath: decoder.codingPath,
-                        debugDescription: "Whole number of altered tones not represented in non-traditional key"
-                    )
-                )
-            }
-            self.kind = .nonTraditional(alteredTones)
+            self.kind = .nonTraditional(try decoder.assemble(from: try decoder.collectArray()))
         }
     }
 
@@ -271,6 +200,82 @@ enum KeyComponent: Decodable {
     case keyStep(Step)
     case keyAlter(Double)
     case keyAccidental(AccidentalValue)
+}
+
+fileprivate extension Decoder {
+    func assemble(from components: [KeyComponent]) throws -> [Key.AlteredTone] {
+        var alteredTones = [Key.AlteredTone]()
+        var previousStep: Step?
+        var previousAlter: Double?
+        for component in components {
+            switch component {
+            case let .keyStep(step):
+                if let unwrappedStep = previousStep {
+                    if let alter = previousAlter {
+                        alteredTones.append(Key.AlteredTone(step: unwrappedStep, alter: alter))
+                        previousStep = step
+                        previousAlter = nil
+                    } else {
+                        // The previous value was also a key-step
+                        throw DecodingError.typeMismatch(
+                            Key.self,
+                            DecodingError.Context(
+                                codingPath: self.codingPath,
+                                debugDescription: "Two key-step values in a row in non-traditional key"
+                            )
+                        )
+                    }
+                } else {
+                    previousStep = step
+                }
+            case let .keyAlter(alter):
+                if previousStep != nil {
+                    previousAlter = alter
+                } else {
+                    // The preceding value was not a key-step
+                    throw DecodingError.typeMismatch(
+                        Key.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "key-alter value not preceded by key-step value in non-traditional key"
+                        )
+                    )
+                }
+            case let .keyAccidental(accidental):
+                if let step = previousStep, let alter = previousAlter {
+                    alteredTones.append(Key.AlteredTone(step: step, alter: alter, accidental: accidental))
+                    // Reset
+                    previousStep = nil
+                    previousAlter = nil
+                } else {
+                    // This accidental was not preceded by a key-step and a key-alter
+                    throw DecodingError.typeMismatch(
+                        Key.self,
+                        DecodingError.Context(
+                            codingPath: self.codingPath,
+                            debugDescription: "key-accidental not preceded by key-step and key-alter in non-traditional key"
+                        )
+                    )
+                }
+            }
+        }
+        if let step = previousStep, let alter = previousAlter {
+            alteredTones.append(Key.AlteredTone(step: step, alter: alter))
+            previousStep = nil
+            previousAlter = nil
+        }
+        guard previousStep == nil, previousAlter == nil else {
+            // Should not have leftover previous step or previous alter
+            throw DecodingError.typeMismatch(
+                Key.self,
+                DecodingError.Context(
+                    codingPath: self.codingPath,
+                    debugDescription: "Whole number of altered tones not represented in non-traditional key"
+                )
+            )
+        }
+        return alteredTones
+    }
 }
 
 extension KeyComponent.CodingKeys: XMLChoiceCodingKey {}

--- a/Sources/MusicXML/Complex Types/MeasureStyle.swift
+++ b/Sources/MusicXML/Complex Types/MeasureStyle.swift
@@ -112,7 +112,7 @@ extension MeasureStyle: Codable {
         try container.encodeIfPresent(number, forKey: .number)
         try font.encode(to: encoder)
         try container.encodeIfPresent(color, forKey: .color)
-        
+
         // FIXME: (upstream) `kind.encode(to: encoder)` should work here
         switch kind {
         case let .beatRepeat(value):

--- a/Sources/MusicXML/Simple Types/YesNoNumber.swift
+++ b/Sources/MusicXML/Simple Types/YesNoNumber.swift
@@ -16,7 +16,7 @@ public enum YesNoNumber {
 extension YesNoNumber: Equatable {}
 extension YesNoNumber: Codable {
     enum CodingKeys: CodingKey {}
-    
+
     public func encode(to encoder: Encoder) throws {
         switch self {
         case let .yesNo(value):

--- a/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
+++ b/Tests/MusicXMLTests/Complex Types/MeasureStyleTests.swift
@@ -20,7 +20,7 @@ class MeasureStyleTests: XCTestCase {
         let expected = MeasureStyle(kind: .multipleRest(MultipleRest(2)))
         XCTAssertEqual(decoded, expected)
     }
-    
+
     func testRoundTripMultipleRest() throws {
         try testRoundTrip(MeasureStyle(kind: .multipleRest(MultipleRest(2))))
     }


### PR DESCRIPTION
Places `assemble` in an `extension` of `Decoder` so as to have access to `codingPath` for error handling. This breaks with the previous convention which would have had `assemble` as a static function in `KeyComponent`. Does this seem acceptable to you guys, @jsbean , @DJBen ?